### PR TITLE
Ignore sentinel BLOCKED/USER-NEED payloads in ACP marker cancel

### DIFF
--- a/scripts/acp_runner.py
+++ b/scripts/acp_runner.py
@@ -174,11 +174,7 @@ async def _run_prompt_locked(
                     result.plan_entries.append(entry_text)
 
     def _early_marker() -> str | None:
-        markers = extract_markers(result.text)
-        for marker in ("BLOCKED", "USER-CONFIRM", "USER-NEED"):
-            if markers.get(marker):
-                return marker
-        return None
+        return early_actionable_marker(extract_markers(result.text))
 
     async def _cancel_prompt(reason: str) -> None:
         with contextlib.suppress(Exception):
@@ -329,6 +325,43 @@ def extract_markers(text: str) -> dict[str, list[str]]:
         if value:  # skip empty captures
             out.setdefault(m.group(1), []).append(value)
     return out
+
+
+# Worker sign-off payloads on BLOCKED:/USER-NEED: that mean "no blocker".
+# Case-insensitive after strip; empty/whitespace-only counts as sentinel too.
+_SENTINEL_MARKER_PAYLOADS = frozenset({
+    "none",
+    "n/a",
+    "na",
+    "-",
+    "no",
+    "nope",
+    "false",
+    "(none)",
+})
+
+
+def is_sentinel_marker_payload(payload: str) -> bool:
+    normalized = payload.strip().casefold()
+    if not normalized:
+        return True
+    return normalized in _SENTINEL_MARKER_PAYLOADS
+
+
+def has_actionable_marker_values(markers: dict[str, list[str]], kind: str) -> bool:
+    values = markers.get(kind) or []
+    if not values:
+        return False
+    if kind in ("BLOCKED", "USER-NEED"):
+        return any(not is_sentinel_marker_payload(v) for v in values)
+    return True
+
+
+def early_actionable_marker(markers: dict[str, list[str]]) -> str | None:
+    for marker in ("BLOCKED", "USER-CONFIRM", "USER-NEED"):
+        if has_actionable_marker_values(markers, marker):
+            return marker
+    return None
 
 
 def _scan_out_of_scope_paths(tool_calls: list[dict[str, Any]], cwd: str | Path) -> list[str]:

--- a/scripts/goalflight_acp_run.py
+++ b/scripts/goalflight_acp_run.py
@@ -87,7 +87,7 @@ from goalflight_os_sandbox import (
     preflight_os_sandbox,
 )
 from goalflight_startup_gate import StartupGate
-from acp_runner import extract_markers, run_prompt
+from acp_runner import extract_markers, has_actionable_marker_values, run_prompt
 
 
 def _resolve_manifest_binary(binary: str) -> str:
@@ -818,7 +818,9 @@ async def run(args: argparse.Namespace) -> dict:
             heartbeat_error=terminal_error,
         )
         if state == "complete" and (
-            markers.get("BLOCKED") or markers.get("USER-NEED") or markers.get("USER-CONFIRM")
+            has_actionable_marker_values(markers, "BLOCKED")
+            or has_actionable_marker_values(markers, "USER-NEED")
+            or markers.get("USER-CONFIRM")
         ):
             state = "blocked"
         payload.update({

--- a/test/fixtures/acp_fake_agent.py
+++ b/test/fixtures/acp_fake_agent.py
@@ -375,6 +375,17 @@ def handle_prompt(req_id: int, params: dict) -> None:
             if message.get("method") == "session/cancel":
                 return
             time.sleep(0.01)
+    if SCENARIO == "blocked_none":
+        text_update(session_id, "RESULT: work done\n")
+        text_update(session_id, "COMPLETE: goal done\n")
+        text_update(session_id, "BLOCKED: none\n")
+        response(req_id, {"sessionId": session_id, "stopReason": "end_turn"})
+        return
+    if SCENARIO == "user_need_none":
+        text_update(session_id, "COMPLETE: goal done\n")
+        text_update(session_id, "USER-NEED: none\n")
+        response(req_id, {"sessionId": session_id, "stopReason": "end_turn"})
+        return
     if SCENARIO == "goal":
         text_update(session_id, "STATUS: working\n")
         text_update(session_id, "COMPLETE: goal done\n")

--- a/test/test_acp_failure_modes.py
+++ b/test/test_acp_failure_modes.py
@@ -25,6 +25,7 @@ from goalflight_acp_client import (  # noqa: E402
     PoolExhaustedError,
 )
 from goalflight_acp_run import adapter_liveness_config, agent_command, decide_terminal_state, spawn_and_handshake_with_retry  # noqa: E402
+from acp_runner import has_actionable_marker_values  # noqa: E402
 from goalflight_liveness import heartbeat_wedge_decision, progress_stall_decision  # noqa: E402
 
 
@@ -557,6 +558,57 @@ def case_terminal_state_endturn_beats_tail_race_wedge() -> None:
     assert state == "failed", state
 
 
+def case_runner_blocked_none_completes() -> None:
+    returncode, status, stdout, stderr = _run_fake_runner(
+        "blocked_none",
+        progress_stall_s=30.0,
+        idle_timeout=5.0,
+        timeout_s=20.0,
+    )
+
+    assert returncode == 0, (stdout, stderr, status)
+    assert status["state"] == "complete", status
+    assert status["ok"] is True, status
+    assert status["error"] is None, status
+    assert status["markers"]["BLOCKED"] == ["none"], status
+    assert status["markers"]["COMPLETE"] == ["goal done"], status
+    assert not has_actionable_marker_values(status["markers"], "BLOCKED")
+
+
+def case_runner_blocked_substantive_cancels() -> None:
+    returncode, status, stdout, stderr = _run_fake_runner(
+        "blocked",
+        progress_stall_s=30.0,
+        heartbeat_interval=1.0,
+        wedge_samples=999,
+        idle_timeout=5.0,
+        timeout_s=20.0,
+    )
+
+    assert returncode != 0, (stdout, stderr, status)
+    assert status["state"] == "blocked", status
+    assert status["ok"] is False, status
+    assert status["error"]["marker"] == "BLOCKED", status
+    assert status["error"]["message"] == "early_marker_cancelled", status
+    assert status["markers"]["BLOCKED"] == ["need maintainer"], status
+
+
+def case_runner_user_need_none_completes() -> None:
+    returncode, status, stdout, stderr = _run_fake_runner(
+        "user_need_none",
+        progress_stall_s=30.0,
+        idle_timeout=5.0,
+        timeout_s=20.0,
+    )
+
+    assert returncode == 0, (stdout, stderr, status)
+    assert status["state"] == "complete", status
+    assert status["ok"] is True, status
+    assert status["error"] is None, status
+    assert status["markers"]["USER-NEED"] == ["none"], status
+    assert not has_actionable_marker_values(status["markers"], "USER-NEED")
+
+
 def case_runner_idle_silent_idle_timeout_reaps() -> None:
     # IdleLivenessGate / on_idle path: a worker that emits nothing and never
     # responds is reaped by the run_prompt idle timeout (not the heartbeat —
@@ -770,6 +822,9 @@ def main() -> None:
     case_runner_remote_dead_silent_turn_hits_remote_wall()
     case_runner_thought_stream_survives_progress_stall_wall()
     case_terminal_state_endturn_beats_tail_race_wedge()
+    case_runner_blocked_none_completes()
+    case_runner_blocked_substantive_cancels()
+    case_runner_user_need_none_completes()
     case_runner_idle_silent_idle_timeout_reaps()
     case_runner_oversized_frame_dropped_then_completes()
     case_runner_goal_mode_progress_stall_backstop()

--- a/test/test_acp_pipe.py
+++ b/test/test_acp_pipe.py
@@ -17,7 +17,13 @@ ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT / "scripts"))
 
 from acp_pool import compute_pool_ceiling, managed_pool  # noqa: E402
-from acp_runner import extract_markers, run_prompt  # noqa: E402
+from acp_runner import (  # noqa: E402
+    early_actionable_marker,
+    extract_markers,
+    has_actionable_marker_values,
+    is_sentinel_marker_payload,
+    run_prompt,
+)
 import goalflight_acp_permits as permits  # noqa: E402
 import goalflight_acp_run  # noqa: E402
 import goalflight_adapter_readiness  # noqa: E402
@@ -661,6 +667,34 @@ async def case_fine_chunks_vendor_no_dup_marker() -> None:
         await conn.kill()
 
 
+async def case_blocked_none_signoff_completes() -> None:
+    conn = await _connect("blocked_none")
+    try:
+        result = await run_prompt(conn, "go", idle_timeout=5)
+        assert result.ok, result
+        assert not result.cancelled_for_marker, result
+        assert result.early_marker is None, result
+        markers = extract_markers(result.text)
+        assert markers["BLOCKED"] == ["none"], markers
+        assert markers["COMPLETE"] == ["goal done"], markers
+        assert early_actionable_marker(markers) is None
+    finally:
+        await conn.kill()
+
+
+async def case_user_need_none_signoff_completes() -> None:
+    conn = await _connect("user_need_none")
+    try:
+        result = await run_prompt(conn, "go", idle_timeout=5)
+        assert result.ok, result
+        assert not result.cancelled_for_marker, result
+        markers = extract_markers(result.text)
+        assert markers["USER-NEED"] == ["none"], markers
+        assert early_actionable_marker(markers) is None
+    finally:
+        await conn.kill()
+
+
 async def case_realtime_blocked_cancels_before_prompt_resolves() -> None:
     conn = await _connect("blocked")
     start = time.monotonic()
@@ -1186,6 +1220,30 @@ def case_marker_parser() -> None:
     assert markers["COMPLETE"] == ["done"]
 
 
+def case_sentinel_marker_payloads_unit() -> None:
+    for payload in ("none", "NONE", "  none  ", "N/A", "(none)", "-", "", "   "):
+        assert is_sentinel_marker_payload(payload), payload
+    assert not is_sentinel_marker_payload("missing API key, cannot proceed")
+    blocked_none = extract_markers(
+        "RESULT:\n- work done\n\nBLOCKED: none\nCOMPLETE: goal done\n"
+    )
+    assert blocked_none["BLOCKED"] == ["none"]
+    assert not has_actionable_marker_values(blocked_none, "BLOCKED")
+    assert early_actionable_marker(blocked_none) is None
+    substantive = extract_markers("BLOCKED: missing API key, cannot proceed\n")
+    assert has_actionable_marker_values(substantive, "BLOCKED")
+    assert early_actionable_marker(substantive) == "BLOCKED"
+    mixed = extract_markers("BLOCKED: none\nBLOCKED: missing API key\n")
+    assert has_actionable_marker_values(mixed, "BLOCKED")
+    assert early_actionable_marker(mixed) == "BLOCKED"
+    user_need_none = extract_markers("USER-NEED: none\n")
+    assert user_need_none["USER-NEED"] == ["none"]
+    assert not has_actionable_marker_values(user_need_none, "USER-NEED")
+    user_need_real = extract_markers("USER-NEED: pick deployment target\n")
+    assert has_actionable_marker_values(user_need_real, "USER-NEED")
+    assert early_actionable_marker(user_need_real) == "USER-NEED"
+
+
 def case_pool_ceiling_fallback(tmp: Path | None = None) -> None:
     missing = ROOT / "test/.missing-env-caveats.md"
     assert compute_pool_ceiling(missing) >= 1
@@ -1215,6 +1273,8 @@ async def amain() -> None:
     await case_pool_inline_threading()
     await case_tool_tracking_closes()
     await case_fine_chunks_vendor_no_dup_marker()
+    await case_blocked_none_signoff_completes()
+    await case_user_need_none_signoff_completes()
     await case_realtime_blocked_cancels_before_prompt_resolves()
     await case_realtime_blocked_cancel_rebuilds_pool_connection()
     await case_run_prompt_cancel_marks_unreusable()
@@ -1226,6 +1286,7 @@ async def amain() -> None:
 
 def main() -> None:
     case_marker_parser()
+    case_sentinel_marker_payloads_unit()
     case_codex_acp_args_injection_unit()
     case_permission_handler_selection_unit()
     case_permission_inline_rejects_nonallow_option_unit()


### PR DESCRIPTION
## Summary
- Add sentinel-payload guards in `acp_runner.py` so sign-off lines like `BLOCKED: none` and `USER-NEED: none` are recorded in `markers` but do not trigger `early_marker_cancelled` or downgrade a successful dispatch to `state="blocked"`.
- Sentinel values (case-insensitive, stripped): `none`, `n/a`, `na`, `-`, `no`, `nope`, `false`, `(none)`, and empty/whitespace.
- Substantive blockers still preempt exactly as before.

## Test plan
- [x] `python3 test/test_acp_pipe.py`
- [x] `python3 test/test_acp_failure_modes.py`
- [x] `case_sentinel_marker_payloads_unit` — sentinel vs substantive classification
- [x] `case_blocked_none_signoff_completes` / `case_runner_blocked_none_completes` — `BLOCKED: none` → complete, exit 0
- [x] `case_runner_blocked_substantive_cancels` — real blocker → blocked, exit 1
- [x] `case_user_need_none_signoff_completes` / `case_runner_user_need_none_completes` — symmetric USER-NEED handling


Made with [Cursor](https://cursor.com)