### PR TITLE
fix(grok): pass --permission-mode auto for grok 0.2.111 file writes

### DIFF
--- a/scripts/goalflight_dispatch.py
+++ b/scripts/goalflight_dispatch.py
@@ -7388,28 +7388,23 @@ def build_worker(args, prompt_path, raw_argv: list[str]):
         # Trade-off: the dispatch ledger no longer records which grok model ran
         # (it's grok's default), in exchange for auto-tracking + no stale pin.
         default_model = None
-        # PERMISSION MODE — pass NO `--permission-mode` flag (do not "fix" by
-        # swapping the value). grok 0.2.39 regression (verified 2026-06-10): in
-        # single-turn `--prompt-file` mode, EVERY `--permission-mode` value stops
-        # the file-write tool from writing — none produce the file; only OMITTING
-        # the flag does. The tail varies by value (probe: grok-composer-2.5-fast,
-        # write-a-file prompt):
-        #   omit-flag    -> file written + DONE marker, rc=0   (the only one that works)
-        #   default      -> 1-byte no-op, no file
-        #   acceptEdits  -> 1-byte no-op, no file   (this is the value we shipped)
-        #   auto         -> 0-byte no-op, no file
-        #   dontAsk      -> prints a normal completion marker but STILL skips the write
-        # The empty no-ops (default/acceptEdits/auto) make the watcher record
-        # worker_dead_no_terminal_marker — how the shipped acceptEdits killed 4
-        # grok-research dispatches (~18-25s, empty tails) on 2026-06-10; dontAsk is
-        # worse, faking a clean finish with no artifact. All values are still listed
-        # in `grok --help`, so this is a CLI regression, not a parse error. No safe
-        # middle-ground value exists, bypassPermissions is too broad, and a
-        # per-dispatch healthcheck would tax every dispatch's critical path — so the
-        # fix is the deterministic omit, locked by a regression test
-        # (tests/python/test_acp_model_passthrough.py). Same lesson as the stale
-        # model note above: grok flags drift; re-validate before trusting one.
-        argv = ["grok", "--prompt-file", str(prompt_path)]
+        # PERMISSION MODE — grok's single-turn `--prompt-file` write behavior is
+        # permission-mode-dependent AND drifts across releases, so this line is
+        # release-coupled. Re-validated per grok version with a write-a-file probe
+        # (prompt asks the worker to create PROOF.txt in --cwd; check it lands):
+        #   grok 0.2.39  (2026-06-10): ONLY omitting the flag wrote; every explicit
+        #                value was an empty no-op -> worker_dead_no_terminal_marker.
+        #   grok 0.2.111 (2026-07-24): behavior INVERTED. omit/default/acceptEdits/
+        #                dontAsk are all 1-byte no-ops (no file); only `auto` and
+        #                `bypassPermissions` write. We pass `auto` — the least-
+        #                privileged value that writes. bypassPermissions also works
+        #                but is broader than a workspace writer needs and matches the
+        #                spirit of the adapter's forbidden blanket-approve flags, so
+        #                it stays out.
+        # If edit-heavy grok dispatches start dying with empty tails after a grok
+        # update, RE-RUN the permission-mode write probe and pick the narrowest value
+        # that writes. Locked by tests/python/test_acp_model_passthrough.py.
+        argv = ["grok", "--prompt-file", str(prompt_path), "--permission-mode", "auto"]
         # Only pin a model when one is EXPLICITLY requested; otherwise omit the
         # flag entirely and let grok's CLI default (grok-4.5) apply.
         selected_model = str(model) if model else default_model

--- a/tests/python/test_acp_model_passthrough.py
+++ b/tests/python/test_acp_model_passthrough.py
@@ -176,15 +176,18 @@ def case_build_worker_injects_model() -> None:
     assert "--auto" not in " ".join(argv_kimi) and "-y" not in argv_kimi, argv_kimi
     # grok-research keeps web tools ON (grok-4.5 supports web_search/web_fetch).
     assert "--disable-web-search" not in argv_research, argv_research
-    # grok 0.2.39 regression: in single-turn `--prompt-file` mode EVERY
-    # `--permission-mode` value stops the file-write tool from writing (none produce
-    # the file); the empty no-ops surface as worker_dead_no_terminal_marker. Omitting
-    # the flag is the only invocation that writes in-cwd non-interactively. Lock the
-    # omit for both presets so a future "re-add acceptEdits" cannot regress
-    # edit-heavy chunks.
+    # grok single-turn `--prompt-file` write behavior is permission-mode-dependent
+    # and drifts across releases (build_worker carries the full per-version probe
+    # log). grok 0.2.111 (2026-07-24): omit/default/acceptEdits/dontAsk are silent
+    # 1-byte no-ops (worker_dead_no_terminal_marker); only `auto` and
+    # `bypassPermissions` actually write. Ship the least-privileged value that
+    # writes — `--permission-mode auto` — and lock it so a future "just omit the
+    # flag" cannot re-break edit-heavy chunks, while keeping the blanket bypass out.
     for agent in ("grok-code", "grok-research"):
         argv = _build(agent, None)
-        assert "--permission-mode" not in argv, (agent, argv)
+        assert "--permission-mode" in argv, (agent, argv)
+        assert argv[argv.index("--permission-mode") + 1] == "auto", (agent, argv)
+        assert "bypassPermissions" not in argv, (agent, argv)
         assert "acceptEdits" not in argv, (agent, argv)
     # raw `-- <cmd>` passthrough ignores model (the orchestrator supplies the cmd).
     assert _build("x", MODEL, raw=["echo", "hi"]) == ["echo", "hi"]


### PR DESCRIPTION
## Problem
grok 0.2.111 **inverted** the single-turn `--prompt-file` write behavior relative to 0.2.39. The `grok-code` / `grok-research` CLI transport built `grok --prompt-file <f> --cwd <d>` with **no** `--permission-mode` (omit was the only value that wrote in 0.2.39). Under 0.2.111 that silently breaks: file-writing dispatches die as `worker_dead_no_terminal_marker` with an empty tail.

## Evidence (write-a-file probe matrix, grok 0.2.111)
| `--permission-mode` | writes file? |
|---|---|
| omit *(previous behavior)* · default · acceptEdits · dontAsk | ❌ silent 1-byte no-op |
| **auto** · bypassPermissions | ✅ writes |

## Fix
Builder now appends **`--permission-mode auto`** — the least-privileged value that writes. `bypassPermissions` also works but is broader than a workspace writer needs and matches the spirit of the adapter's forbidden blanket-approve flags, so it's kept out.

- `scripts/goalflight_dispatch.py`: append `--permission-mode auto`; comment block rewritten with the per-version probe log (this line is release-coupled — re-run the probe on the next grok drift).
- `tests/python/test_acp_model_passthrough.py`: assertion flipped from "permission-mode absent" to "requires `auto`, forbids `bypassPermissions`".

## Validation
Real `goalflight_dispatch.py --agent grok-code` dispatch → terminal state `complete`, target file written on disk. `test_acp_model_passthrough.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)