### PR TITLE
Add Grok Bot host port (controller wrapper + exit-as-wake listen)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,11 @@ incremented when meaningful skill behaviour changes.
   user's Mac (label `goalflight-grokbot`; MVP depth 1; portable pool is
   4). The 900s quiet timeout is this host's frontier ping, not Claude's
   120s follow-stream heartbeat. Do not arm unbounded `supervise`
-  expecting per-line wakes. Success terminal is `!COMPLETE`. No native
+  expecting per-line wakes. Success terminal is `!COMPLETE`. Judgment-bearing
+  Grok Bot Task / executor prompts reuse the Claude host-subagent pin
+  (`protocols/subagent-preamble.md` + triggered
+  `protocols/worker-context-package.md`); executors start blank on the
+  box and must name `machineId` plus Mac absolute paths. No native
   mail transport in this port. Unsupported the same way Cursor /
   OpenCode / Codex orchestrator ports are. See `docs/hosts/grok-bot.md`.
 - **Watchlist two-tier wedge detector (`goalflight_wedge_watch.py`).** Cheap

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ incremented when meaningful skill behaviour changes.
 
 ### Added
 
+- **Grok Bot host port.** Controller-only wrapper at
+  `configs/grok-bot/skills/goal-flight/SKILL.md`, adapter
+  `adapters/grok-bot.json` (distinct from Grok CLI `adapters/grok.json`),
+  and `./install.sh grok-bot` copying the wrapper into the Grok Bot
+  workflows library. Unsupported the same way Cursor / OpenCode / Codex
+  orchestrator ports are. See `docs/hosts/grok-bot.md`.
 - **Watchlist two-tier wedge detector (`goalflight_wedge_watch.py`).** Cheap
   path is one `stat` of the tail (mtime + size). After the tail has been
   idle longer than a data-derived probation (1080s, above p99=965.7s of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,11 @@ incremented when meaningful skill behaviour changes.
   workflows library. Grok Bot Executors are a first-class host delegate
   lane on this port (not Claude's last-resort Host Agent rule); kimi3
   reviews go through `--agent moonshot`. Wake is exit-as-wake: a tracked
-  `goalflight_messages.py listen --report-pending` on the user's Mac
-  (MVP depth 1; portable pool is 4). Do not arm unbounded `supervise`
-  expecting per-line wakes; `!FINISHED` aliases to `!COMPLETE`. No native
+  `goalflight_messages.py listen --report-pending --timeout-s 900` on the
+  user's Mac (label `goalflight-grokbot`; MVP depth 1; portable pool is
+  4). The 900s quiet timeout is this host's frontier ping, not Claude's
+  120s follow-stream heartbeat. Do not arm unbounded `supervise`
+  expecting per-line wakes. Success terminal is `!COMPLETE`. No native
   mail transport in this port. Unsupported the same way Cursor /
   OpenCode / Codex orchestrator ports are. See `docs/hosts/grok-bot.md`.
 - **Watchlist two-tier wedge detector (`goalflight_wedge_watch.py`).** Cheap

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,9 @@ incremented when meaningful skill behaviour changes.
   Hard Invariants quote-check (`goalflight_grok_bot_listen.py` banner).
   The operator is not the compaction mailman; the one wake-hygiene job
   is re-arming listen doorbells after a host update or token-pause,
-  surfaced as roster `wake unarmed`. No native
+  surfaced as roster `wake unarmed`. Inter-controller traffic is only
+  `post --to-controller`; do not ask the user to paste or to tell
+  another session to check mail. No native
   mail transport in this port. Unsupported the same way Cursor /
   OpenCode / Codex orchestrator ports are. See `docs/hosts/grok-bot.md`.
 - **Watchlist two-tier wedge detector (`goalflight_wedge_watch.py`).** Cheap

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,10 @@ incremented when meaningful skill behaviour changes.
   `configs/grok-bot/skills/goal-flight/SKILL.md`, adapter
   `adapters/grok-bot.json` (distinct from Grok CLI `adapters/grok.json`),
   and `./install.sh grok-bot` copying the wrapper into the Grok Bot
-  workflows library. Unsupported the same way Cursor / OpenCode / Codex
-  orchestrator ports are. See `docs/hosts/grok-bot.md`.
+  workflows library. Grok Bot Executors are a first-class host delegate
+  lane on this port (not Claude's last-resort Host Agent rule); kimi3
+  reviews go through `--agent moonshot`. Unsupported the same way Cursor /
+  OpenCode / Codex orchestrator ports are. See `docs/hosts/grok-bot.md`.
 - **Watchlist two-tier wedge detector (`goalflight_wedge_watch.py`).** Cheap
   path is one `stat` of the tail (mtime + size). After the tail has been
   idle longer than a data-derived probation (1080s, above p99=965.7s of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ incremented when meaningful skill behaviour changes.
   workflows library. Grok Bot Executors are a first-class host delegate
   lane on this port (not Claude's last-resort Host Agent rule); kimi3
   reviews go through `--agent moonshot`. Wake is exit-as-wake: a tracked
-  `goalflight_messages.py listen --report-pending --timeout-s 900` on the
+  `goalflight_grok_bot_listen.py --report-pending --timeout-s 900` on the
   user's Mac (label `goalflight-grokbot`; MVP depth 1; portable pool is
   4). The 900s quiet timeout is this host's frontier ping, not Claude's
   120s follow-stream heartbeat. Do not arm unbounded `supervise`
@@ -35,7 +35,10 @@ incremented when meaningful skill behaviour changes.
   box and must name `machineId` plus Mac absolute paths. Compaction is
   write-early file state (`state-handoff.md` Before compact or sleep on
   the 900s frontier ping and before long waves); there is no `/compact`
-  UI and no keep-vs-toss prompt. No native
+  UI and no keep-vs-toss prompt. Do not port the Claude context-meter or
+  SessionStart hooks; every listen ring/timeout is a mini-resume plus a
+  Hard Invariants quote-check (`goalflight_grok_bot_listen.py` banner).
+  No native
   mail transport in this port. Unsupported the same way Cursor /
   OpenCode / Codex orchestrator ports are. See `docs/hosts/grok-bot.md`.
 - **Watchlist two-tier wedge detector (`goalflight_wedge_watch.py`).** Cheap

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,10 @@ incremented when meaningful skill behaviour changes.
   Grok Bot Task / executor prompts reuse the Claude host-subagent pin
   (`protocols/subagent-preamble.md` + triggered
   `protocols/worker-context-package.md`); executors start blank on the
-  box and must name `machineId` plus Mac absolute paths. No native
+  box and must name `machineId` plus Mac absolute paths. Compaction is
+  write-early file state (`state-handoff.md` Before compact or sleep on
+  the 900s frontier ping and before long waves); there is no `/compact`
+  UI and no keep-vs-toss prompt. No native
   mail transport in this port. Unsupported the same way Cursor /
   OpenCode / Codex orchestrator ports are. See `docs/hosts/grok-bot.md`.
 - **Watchlist two-tier wedge detector (`goalflight_wedge_watch.py`).** Cheap

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,11 @@ incremented when meaningful skill behaviour changes.
   and `./install.sh grok-bot` copying the wrapper into the Grok Bot
   workflows library. Grok Bot Executors are a first-class host delegate
   lane on this port (not Claude's last-resort Host Agent rule); kimi3
-  reviews go through `--agent moonshot`. Unsupported the same way Cursor /
+  reviews go through `--agent moonshot`. Wake is exit-as-wake: a tracked
+  `goalflight_messages.py listen --report-pending` on the user's Mac
+  (MVP depth 1; portable pool is 4). Do not arm unbounded `supervise`
+  expecting per-line wakes; `!FINISHED` aliases to `!COMPLETE`. No native
+  mail transport in this port. Unsupported the same way Cursor /
   OpenCode / Codex orchestrator ports are. See `docs/hosts/grok-bot.md`.
 - **Watchlist two-tier wedge detector (`goalflight_wedge_watch.py`).** Cheap
   path is one `stat` of the tail (mtime + size). After the tail has been

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,9 @@ incremented when meaningful skill behaviour changes.
   UI and no keep-vs-toss prompt. Do not port the Claude context-meter or
   SessionStart hooks; every listen ring/timeout is a mini-resume plus a
   Hard Invariants quote-check (`goalflight_grok_bot_listen.py` banner).
-  No native
+  The operator is not the compaction mailman; the one wake-hygiene job
+  is re-arming listen doorbells after a host update or token-pause,
+  surfaced as roster `wake unarmed`. No native
   mail transport in this port. Unsupported the same way Cursor /
   OpenCode / Codex orchestrator ports are. See `docs/hosts/grok-bot.md`.
 - **Watchlist two-tier wedge detector (`goalflight_wedge_watch.py`).** Cheap

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,11 +57,12 @@ Optional: exercise host install paths locally:
 ./install.sh cursor /path/to/your/project    # dry-run by default via setup.sh
 ./install.sh opencode /path/to/your/project
 ./install.sh codex
+./install.sh grok-bot
 ```
 
 See `README.md`, `docs/architecture.md`, and host notes in
-`docs/hosts/cursor.md` and `docs/hosts/opencode.md` for architecture and install
-details.
+`docs/hosts/cursor.md`, `docs/hosts/opencode.md`, and `docs/hosts/grok-bot.md`
+for architecture and install details.
 
 ## Running tests
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ one-commit-per-chunk work on your branch; nothing is pushed without your permiss
 **Hosts and workers.** [Claude Code](https://claude.ai/code) is the supported
 orchestrator. [Codex](https://github.com/openai/codex) is the standard worker; cursor,
 grok, claude-cli, and other worker adapters also serve. Unsupported orchestrator ports
-for Codex, Cursor, and OpenCode ship in-repo.
+for Codex, Cursor, OpenCode, and Grok Bot ship in-repo.
 
 **What the orchestrator session is for**: requirements gathering, architecture decisions,
 question escalation, and monitoring — not execution. The orchestrator holds enough context
@@ -39,7 +39,7 @@ Install once:
 git clone https://github.com/simonrowland/goal-flight.git ~/.claude/skills/goal-flight
 ```
 
-(Orchestrator ports for Codex / Cursor / OpenCode exist but are unsupported — install
+(Orchestrator ports for Codex / Cursor / OpenCode / Grok Bot exist but are unsupported — install
 commands are under [Host install notes](#host-install-notes).)
 
 Primary platform is macOS. Linux hosts work too ([docs/hosts/linux.md](docs/hosts/linux.md));
@@ -296,7 +296,7 @@ Also recommended:
 
 ## Host install notes
 
-Orchestrator ports for Codex, Cursor, and OpenCode are implemented and unsupported; the
+Orchestrator ports for Codex, Cursor, OpenCode, and Grok Bot are implemented and unsupported; the
 Claude Code wrapper is the maintained path. To install a port anyway:
 
 ```bash
@@ -304,6 +304,7 @@ git clone https://github.com/simonrowland/goal-flight.git ~/.goal-flight && cd ~
 ./install.sh cursor /path/to/your/project
 ./install.sh opencode /path/to/your/project
 ./install.sh codex
+./install.sh grok-bot
 ```
 
 After source `SKILL.md`, `commands/`, `protocols/`, `templates/`, or `adapters/`
@@ -315,10 +316,12 @@ which usually correlates with the other directories being stale too. Run
 the resync command in the probe's `resync_command` field; text mode prints
 `installed_skill_md_hash` WARNs.
 
-Same flags via `setup.sh`: `--cursor-install`, `--opencode-install`, and
-`--codex-install` (each implies `--apply --yes`). Dry-run, link-to-Claude, and
-agents-standard paths are in [docs/hosts/cursor.md](docs/hosts/cursor.md) and
-[docs/hosts/opencode.md](docs/hosts/opencode.md).
+Same flags via `setup.sh`: `--cursor-install`, `--opencode-install`,
+`--codex-install`, and `--grok-bot-install` (each implies `--apply --yes`).
+Dry-run, link-to-Claude, and agents-standard paths are in
+[docs/hosts/cursor.md](docs/hosts/cursor.md),
+[docs/hosts/opencode.md](docs/hosts/opencode.md), and
+[docs/hosts/grok-bot.md](docs/hosts/grok-bot.md).
 
 After any install, run doctor:
 `python3 scripts/goalflight_doctor.py --project-root /path/to/your/project`.

--- a/README.md
+++ b/README.md
@@ -305,6 +305,10 @@ git clone https://github.com/simonrowland/goal-flight.git ~/.goal-flight && cd ~
 ./install.sh opencode /path/to/your/project
 ./install.sh codex
 ./install.sh grok-bot
+# default workflows root is /home/box/agent-data/workflows (Grok Bot box).
+# From a Mac checkout pass GOALFLIGHT_GROK_BOT_WORKFLOWS or:
+# ./install.sh grok-bot /path/to/workflows
+# This repo does not invent a second Mac default library root.
 ```
 
 After source `SKILL.md`, `commands/`, `protocols/`, `templates/`, or `adapters/`
@@ -325,6 +329,10 @@ Dry-run, link-to-Claude, and agents-standard paths are in
 
 After any install, run doctor:
 `python3 scripts/goalflight_doctor.py --project-root /path/to/your/project`.
+Grok Bot `installed_skill_drift` hashes the box workflows library (or
+`GOALFLIGHT_GROK_BOT_WORKFLOWS`). A Mac `--project-root` doctor without
+that override will not see `/home/box/...`; check drift on the box, or
+pass the override.
 
 ### Windows
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -64,7 +64,7 @@ Extended: `protocols/guidance-extended.md` §activation-check
 ## Per-host pointers
 
 Per-host pointers tell non-native orchestrators where their installed wrapper lives.
-If you are a non-Claude orchestrator (codex, grok, cursor, opencode), load your
+If you are a non-Claude orchestrator (codex, grok, grok-bot, cursor, opencode), load your
 host wrapper first, then root `SKILL.md` as canonical workflow:
 
 | Host | Installed wrapper path |
@@ -72,6 +72,7 @@ host wrapper first, then root `SKILL.md` as canonical workflow:
 | codex | `~/.codex/plugins/cache/goal-flight/goal-flight/<version>/skills/goal-flight/SKILL.md` or `~/.codex/skills/goal-flight/SKILL.md` |
 | cursor | `.cursor/skills/goal-flight/SKILL.md`, `~/.cursor/skills/goal-flight/SKILL.md`, or `~/.agents/skills/goal-flight/SKILL.md` |
 | grok | `~/.grok/skills/goal-flight/SKILL.md` or generated path from `configs/grok/skills/goal-flight/SKILL.md` |
+| grok-bot | `/home/box/agent-data/workflows/goal-flight/SKILL.md` (workflows library; `GOALFLIGHT_GROK_BOT_WORKFLOWS` override) or `configs/grok-bot/skills/goal-flight/SKILL.md` |
 | opencode | `.opencode/skills/goal-flight/SKILL.md`, `~/.config/opencode/skills/goal-flight/SKILL.md`, or `~/.agents/skills/goal-flight/SKILL.md` |
 
 **Stale-wrapper warning:** non-native hosts hold a *copy* of `SKILL.md`. If

--- a/adapters/agent-adapter.schema.json
+++ b/adapters/agent-adapter.schema.json
@@ -49,6 +49,7 @@
         "codex",
         "cursor",
         "grok",
+        "grok-bot",
         "moonshot",
         "gemini",
         "qwen",

--- a/adapters/grok-bot.json
+++ b/adapters/grok-bot.json
@@ -271,23 +271,28 @@
       "notes": "Verified on the Grok Bot box as the user-created workflows library. Mac-side library roots are not a second invented default; set the override when install does not run on that box."
     },
     "wake": {
-      "path": "goalflight_messages.py listen --report-pending",
+      "path": "goalflight_messages.py listen --report-pending --timeout-s 900",
       "contract": "exit-as-wake",
-      "arm_on": "user Mac project-root + --controller-label",
+      "controller_label": "goalflight-grokbot",
+      "arm_on": "user Mac project-root + --controller-label goalflight-grokbot",
+      "timeout_s": 900,
+      "timeout_purpose": "frontier reminder (anti-stall); host-local listen default, not the 120s Claude follow-stream heartbeat",
       "mvp_depth": 1,
       "full_depth": 4,
       "on_ring": "relay --drain, act, re-arm",
+      "on_timeout": "status + task next, re-arm",
       "detached": "forbidden; listen exit 4",
       "not": [
         "unbounded supervise as a Grok Bot background shell",
         "per-line persistent stdout monitor",
+        "Claude 120s follow-stream heartbeat as a Grok Bot arm",
         "Settings monitor widget",
         "same-turn regex-wait on live supervise as the session monitor",
-        "native mail transport"
+        "native mail transport",
+        "global supervise/follow cadence change"
       ],
       "terminals": ["COMPLETE", "READY", "FAILED", "BLOCKED", "USER-NEED"],
-      "finished_alias": "COMPLETE",
-      "notes": "Grok Bot notifies on tracked Task/executor or Shell completion only. Journal remains durable truth; missed wake is latency. Resume pulls status + task next + relay --new."
+      "notes": "Grok Bot notifies on tracked Task/executor or Shell completion only. Success terminal is COMPLETE. Journal remains durable truth; missed wake is latency. Resume pulls status + task next + relay --new. Full listen pool: put --timeout-s 900 on one slot only."
     },
     "same_provider_policy_notes": "forbid_self_review: a Grok Bot controller must not Type-1-review a grok-code worker. Independent reviews go to --agent moonshot (kimi3 / Kimi Code CLI) or --agent codex, or gstack on those engines.",
     "model_notes": "No model id is pinned. Do not reintroduce a pin here. kimi3 is the moonshot dispatch preset (adapters/moonshot.json default_model kimi-code/k3), not a new agent_id.",

--- a/adapters/grok-bot.json
+++ b/adapters/grok-bot.json
@@ -272,16 +272,16 @@
       "notes": "Verified on the Grok Bot box as the user-created workflows library. Mac-side library roots are not a second invented default; set the override when install does not run on that box."
     },
     "wake": {
-      "path": "goalflight_messages.py listen --report-pending --timeout-s 900",
+      "path": "goalflight_grok_bot_listen.py --report-pending --timeout-s 900",
       "contract": "exit-as-wake",
       "controller_label": "goalflight-grokbot",
       "arm_on": "user Mac project-root + --controller-label goalflight-grokbot",
       "timeout_s": 900,
-      "timeout_purpose": "frontier reminder (anti-stall); host-local listen default, not the 120s Claude follow-stream heartbeat",
+      "timeout_purpose": "frontier reminder and 80% hint substitute; host-local listen default, not the 120s Claude follow-stream heartbeat",
       "mvp_depth": 1,
       "full_depth": 4,
-      "on_ring": "relay --drain, act, re-arm",
-      "on_timeout": "handoff write + status + task next, re-arm",
+      "on_ring": "drain, act, handoff write, quote-check, re-arm, task next",
+      "on_timeout": "handoff write, quote-check, re-arm, task next",
       "detached": "forbidden; listen exit 4",
       "not": [
         "unbounded supervise as a Grok Bot background shell",
@@ -290,17 +290,30 @@
         "Settings monitor widget",
         "same-turn regex-wait on live supervise as the session monitor",
         "native mail transport",
-        "global supervise/follow cadence change"
+        "global supervise/follow cadence change",
+        "Claude context-meter / PostToolUse additionalContext",
+        "SessionStart hook"
       ],
       "terminals": ["COMPLETE", "READY", "FAILED", "BLOCKED", "USER-NEED"],
-      "notes": "Grok Bot notifies on tracked Task/executor or Shell completion only. Success terminal is COMPLETE. Journal remains durable truth; missed wake is latency. Resume pulls status + task next + relay --new. Full listen pool: put --timeout-s 900 on one slot only. Listen exit 1 also writes the state-handoff Before compact or sleep block — there is no /compact warning."
+      "notes": "Grok Bot notifies on tracked Task/executor or Shell completion only. Success terminal is COMPLETE. Journal remains durable truth; missed wake is latency. Resume pulls status + task next + relay --new. Full listen pool: put --timeout-s 900 on one slot only. Every listen exit is a mini-resume: flush state-handoff Before compact or sleep, then quote-check. The grok-bot listen wrapper prints that quote-check on stdout."
     },
     "compaction": {
+      "strategy": "autocompact + keep handoff current",
       "controller_authored_compact": false,
       "keep_vs_toss_prompt": false,
       "host_may_summarize_unannounced": true,
+      "context_meter": false,
+      "session_start_hook": false,
+      "eighty_percent_substitute": "listen --timeout-s 900",
       "directed_compact_is": "protocols/state-handoff.md Before compact or sleep",
-      "write_on": ["listen exit 1 (900s frontier ping)", "before long waves"],
+      "write_on": ["listen exit 0 (ring)", "listen exit 1 (900s frontier ping)", "before long waves"],
+      "quote_check_on": "every listen ring or timeout",
+      "quote_check_externalized": [
+        "wrapper Freshness preamble",
+        "goalflight_grok_bot_listen.py exit banner",
+        "optional operator profile sentence"
+      ],
+      "mini_resume_on_wake": true,
       "resume_notes_slots": ["ENVIRONMENT", "IDEAS", "DECISIONS", "FACTS", "CARRIERS"],
       "no_task_tables_in_resume_notes": true,
       "chat_summaries": "hints, not substitutes",
@@ -310,7 +323,10 @@
       "not": [
         "invent a compact UI",
         "ask the user to compact",
-        "emulate Claude compact prompt in chat"
+        "emulate Claude compact prompt in chat",
+        "port scripts/hooks/goalflight-context-meter.sh",
+        "port SessionStart watchdog",
+        "fake window-percent meter"
       ]
     },
     "same_provider_policy_notes": "forbid_self_review: a Grok Bot controller must not Type-1-review a grok-code worker. Independent reviews go to --agent moonshot (kimi3 / Kimi Code CLI) or --agent codex, or gstack on those engines.",

--- a/adapters/grok-bot.json
+++ b/adapters/grok-bot.json
@@ -360,6 +360,19 @@
         "no_clone_onto_box": true,
         "no_parallel_package_format": true
       }
+    },
+    "mail": {
+      "inter_controller": "goalflight_messages.py post --to-controller",
+      "grok_bot_joins_journal": true,
+      "send_to_agent": "optional extra ping among grok-bot agents only",
+      "send_to_agent_is_work_inbox": false,
+      "send_to_agent_bridges_battery_controllers": false,
+      "deafness": "re-arm listen, not user-as-mailman",
+      "not": [
+        "ask the user to paste mail",
+        "ask the user to tell another session to check mail",
+        "user-as-mailman"
+      ]
     }
   }
 }

--- a/adapters/grok-bot.json
+++ b/adapters/grok-bot.json
@@ -271,9 +271,23 @@
       "notes": "Verified on the Grok Bot box as the user-created workflows library. Mac-side library roots are not a second invented default; set the override when install does not run on that box."
     },
     "wake": {
-      "path": "goalflight_messages.py listen",
-      "not": "supervise persistent stdout monitor",
-      "notes": "Grok Bot has no persistent: true stdout monitor. Use the portable listen doorbell (exit-as-wake). Background Task completion may revive the parent for recon; that is not a mail doorbell."
+      "path": "goalflight_messages.py listen --report-pending",
+      "contract": "exit-as-wake",
+      "arm_on": "user Mac project-root + --controller-label",
+      "mvp_depth": 1,
+      "full_depth": 4,
+      "on_ring": "relay --drain, act, re-arm",
+      "detached": "forbidden; listen exit 4",
+      "not": [
+        "unbounded supervise as a Grok Bot background shell",
+        "per-line persistent stdout monitor",
+        "Settings monitor widget",
+        "same-turn regex-wait on live supervise as the session monitor",
+        "native mail transport"
+      ],
+      "terminals": ["COMPLETE", "READY", "FAILED", "BLOCKED", "USER-NEED"],
+      "finished_alias": "COMPLETE",
+      "notes": "Grok Bot notifies on tracked Task/executor or Shell completion only. Journal remains durable truth; missed wake is latency. Resume pulls status + task next + relay --new."
     },
     "same_provider_policy_notes": "forbid_self_review: a Grok Bot controller must not Type-1-review a grok-code worker. Independent reviews go to --agent moonshot (kimi3 / Kimi Code CLI) or --agent codex, or gstack on those engines.",
     "model_notes": "No model id is pinned. Do not reintroduce a pin here. kimi3 is the moonshot dispatch preset (adapters/moonshot.json default_model kimi-code/k3), not a new agent_id.",

--- a/adapters/grok-bot.json
+++ b/adapters/grok-bot.json
@@ -281,7 +281,7 @@
       "mvp_depth": 1,
       "full_depth": 4,
       "on_ring": "relay --drain, act, re-arm",
-      "on_timeout": "status + task next, re-arm",
+      "on_timeout": "handoff write + status + task next, re-arm",
       "detached": "forbidden; listen exit 4",
       "not": [
         "unbounded supervise as a Grok Bot background shell",
@@ -293,7 +293,25 @@
         "global supervise/follow cadence change"
       ],
       "terminals": ["COMPLETE", "READY", "FAILED", "BLOCKED", "USER-NEED"],
-      "notes": "Grok Bot notifies on tracked Task/executor or Shell completion only. Success terminal is COMPLETE. Journal remains durable truth; missed wake is latency. Resume pulls status + task next + relay --new. Full listen pool: put --timeout-s 900 on one slot only."
+      "notes": "Grok Bot notifies on tracked Task/executor or Shell completion only. Success terminal is COMPLETE. Journal remains durable truth; missed wake is latency. Resume pulls status + task next + relay --new. Full listen pool: put --timeout-s 900 on one slot only. Listen exit 1 also writes the state-handoff Before compact or sleep block — there is no /compact warning."
+    },
+    "compaction": {
+      "controller_authored_compact": false,
+      "keep_vs_toss_prompt": false,
+      "host_may_summarize_unannounced": true,
+      "directed_compact_is": "protocols/state-handoff.md Before compact or sleep",
+      "write_on": ["listen exit 1 (900s frontier ping)", "before long waves"],
+      "resume_notes_slots": ["ENVIRONMENT", "IDEAS", "DECISIONS", "FACTS", "CARRIERS"],
+      "no_task_tables_in_resume_notes": true,
+      "chat_summaries": "hints, not substitutes",
+      "advisory_host_memory": ["profile", "update_state", "routines"],
+      "canonical_memory": "repo_files",
+      "resume_wake": "skip commands/resume.md STEP 1.5 supervise; arm portable listen pool",
+      "not": [
+        "invent a compact UI",
+        "ask the user to compact",
+        "emulate Claude compact prompt in chat"
+      ]
     },
     "same_provider_policy_notes": "forbid_self_review: a Grok Bot controller must not Type-1-review a grok-code worker. Independent reviews go to --agent moonshot (kimi3 / Kimi Code CLI) or --agent codex, or gstack on those engines.",
     "model_notes": "No model id is pinned. Do not reintroduce a pin here. kimi3 is the moonshot dispatch preset (adapters/moonshot.json default_model kimi-code/k3), not a new agent_id.",

--- a/adapters/grok-bot.json
+++ b/adapters/grok-bot.json
@@ -55,10 +55,15 @@
     "write_file": {"host_tools": ["workspace edit"], "constraints": ["authorized edit scope only"]},
     "search": {"host_tools": ["workspace search"], "constraints": ["filtered search"]},
     "delegate": {
-      "host_tools": ["Grok Bot Task/executor", "goalflight_dispatch.py CLI adapters"],
+      "host_tools": [
+        "Grok Bot Task/executor",
+        "goalflight_dispatch.py CLI adapters"
+      ],
       "constraints": [
-        "Task/executor is recon, analysis, and review only",
-        "code-writing chunks use existing CLI adapters on the Mac checkout",
+        "Executor is a first-class host delegate surface on grok-bot, distinct from CLI ACP/bash-tail workers",
+        "choose Executor vs CLI from token/budget and task shape; do not treat Executor as last-resort",
+        "CLI code workers: --agent codex, grok-code, or moonshot (kimi3 via adapters/moonshot.json; no kimi3 agent id)",
+        "independent reviews: --agent moonshot or --agent codex; forbid_self_review blocks Type-1 review of grok-code",
         "Cloud Agents are optional GitHub-branch/PR workers only, never the default"
       ]
     },
@@ -270,7 +275,20 @@
       "not": "supervise persistent stdout monitor",
       "notes": "Grok Bot has no persistent: true stdout monitor. Use the portable listen doorbell (exit-as-wake). Background Task completion may revive the parent for recon; that is not a mail doorbell."
     },
-    "same_provider_policy_notes": "forbid_self_review: a Grok Bot controller must not Type-1-review a grok-code worker. Independent engine (codex/gstack) remains the default.",
-    "model_notes": "No model id is pinned. Do not reintroduce a pin here."
+    "same_provider_policy_notes": "forbid_self_review: a Grok Bot controller must not Type-1-review a grok-code worker. Independent reviews go to --agent moonshot (kimi3 / Kimi Code CLI) or --agent codex, or gstack on those engines.",
+    "model_notes": "No model id is pinned. Do not reintroduce a pin here. kimi3 is the moonshot dispatch preset (adapters/moonshot.json default_model kimi-code/k3), not a new agent_id.",
+    "routing": {
+      "executor_is_first_class": true,
+      "claude_last_resort_rule_does_not_apply": true,
+      "code_writing": {
+        "healthy_capacity": ["codex", "grok-code", "moonshot"],
+        "alternate": "Grok Bot Task/executor when cheaper, available, or host-native"
+      },
+      "reviews": {
+        "independent": ["moonshot", "codex"],
+        "notes": "kimi3 reviews use --agent moonshot. Do not invent a kimi3 agent id."
+      },
+      "host_native_executor": ["recon", "synthesis", "mail", "status", "planning"]
+    }
   }
 }

--- a/adapters/grok-bot.json
+++ b/adapters/grok-bot.json
@@ -1,0 +1,276 @@
+{
+  "schema": "goalflight.agent-adapter.v1",
+  "agent_id": "grok-bot",
+  "display_name": "Grok Bot",
+  "agent_family": "grok",
+  "providers": {
+    "controller_provider": "xai",
+    "model_provider": "xai",
+    "same_provider_policy": "forbid_self_review"
+  },
+  "support": {
+    "controller": {
+      "capability": "supported",
+      "evidence": [
+        "survey: Grok Bot desktop agents load user-created SKILL.md workflows and can Shell a registered Mac",
+        "repo: host wrapper at configs/grok-bot/skills/goal-flight/SKILL.md projects the portable core",
+        "note: this is a controller host port, not a replacement for adapters/grok.json (grok agent stdio)"
+      ],
+      "readiness_requirements": ["auth_optional", "status_contract"],
+      "fallback": "config_only"
+    },
+    "worker": {
+      "capability": "unsupported",
+      "transport": [],
+      "readiness_requirements": [],
+      "fallback": "unsupported"
+    }
+  },
+  "local_readiness_state": {
+    "storage": "machine-local, never checked in",
+    "path_pattern": "$XDG_STATE_HOME/goal-flight/readiness/<agent>.json",
+    "controller": "probe_required",
+    "worker": "unsupported",
+    "last_probe_ids": ["grok-bot-workflows-library"],
+    "updated_at": null
+  },
+  "live_gate": {
+    "function": "validate_adapter_gate",
+    "controller_allowed_expr": "support.controller.capability == supported && local_readiness.controller == ready",
+    "worker_allowed_expr": "support.worker.capability == supported && local_readiness.worker == ready && requested_transport is verified",
+    "default": "deny",
+    "support_status_enum": ["unsupported", "config_only", "probe_required", "candidate", "not_installed", "forbidden-arg", "failed", "blocked"],
+    "return_fields": ["allowed", "reason", "required_probe_ids", "blocked_fields", "safe_next_action", "live_controller_allowed", "live_worker_dispatch_allowed"]
+  },
+  "tool_name_map": {
+    "shell_exec": {
+      "host_tools": ["Grok Bot Shell"],
+      "constraints": [
+        "target the user's registered computer with a machineId",
+        "do not run CLI workers on the Grok Bot box",
+        "safe probes only"
+      ]
+    },
+    "read_file": {"host_tools": ["workspace file read"], "constraints": ["workspace reads only"]},
+    "write_file": {"host_tools": ["workspace edit"], "constraints": ["authorized edit scope only"]},
+    "search": {"host_tools": ["workspace search"], "constraints": ["filtered search"]},
+    "delegate": {
+      "host_tools": ["Grok Bot Task/executor", "goalflight_dispatch.py CLI adapters"],
+      "constraints": [
+        "Task/executor is recon, analysis, and review only",
+        "code-writing chunks use existing CLI adapters on the Mac checkout",
+        "Cloud Agents are optional GitHub-branch/PR workers only, never the default"
+      ]
+    },
+    "ask_user": {"host_tools": ["USER-NEED marker"], "constraints": ["block on ambiguity"]},
+    "plan_update": {"host_tools": ["status markers"], "constraints": ["controller tracks plan externally"]},
+    "memory_search": {
+      "host_tools": ["repo resume notes", "Grok Bot session state"],
+      "constraints": ["repo files remain canonical"]
+    },
+    "browser_ui": {
+      "host_tools": ["browser tool if host exposes one"],
+      "constraints": ["only when available"]
+    }
+  },
+  "invocation": {
+    "skill_triggers": ["goal-flight", "Grok Bot controller"],
+    "commands": ["goal-flight host wrapper"],
+    "exec": {
+      "kind": "native_tool",
+      "binary": null,
+      "args": [],
+      "arg_policy": {
+        "required_safe_args": [],
+        "forbidden_args": ["--yolo", "-y", "--dangerously-*", "--dangerously-bypass-approvals-and-sandbox", "--dangerously-skip-permissions", "--allow-dangerously-skip-permissions", "--always-approve", "--allow-all-tools", "--trust-all-tools", "--auto-approve", "--auto-accept", "--skip-permissions", "--no-sandbox", "--disable-sandbox", "--sandbox-disable"],
+        "requires_explicit_justification": ["--bare", "--auto", "--headless-with-approval-bypass"],
+        "reject_in": ["invocation", "probes", "generated_wrappers", "checked_in_configs"]
+      },
+      "stdin": "none",
+      "cwd_policy": "repo_required",
+      "output_contract": {
+        "parser": "status_json",
+        "completion_detection": "unsupported",
+        "final_event": null,
+        "final_regex": null,
+        "exit_code_policy": "ignored_never",
+        "resume_args": [],
+        "goal_mode_eligible": false
+      }
+    }
+  },
+  "permission_surface": {
+    "file_reads": ["workspace files"],
+    "file_writes": ["authorized edit scope only"],
+    "shell": {
+      "allowed_families": ["safe probes", "test runner"],
+      "forbidden_families": ["permission bypass", "destructive reset", "raw web fetch"]
+    },
+    "network": {
+      "allowed": false,
+      "user_gate": true,
+      "notes": "Auth/model calls are not discovery probes. CLI workers run on the registered Mac, not the Grok Bot box."
+    },
+    "browser_ui": {"allowed": false, "user_gate": true, "notes": "No verified browser UI contract."},
+    "memory_writes": {"allowed": false, "backend": "repo_files"},
+    "plugin_sandbox": {"mode": "none", "declared_permissions": []},
+    "os_sandbox": {
+      "supported_profiles": ["off"],
+      "default_profile": "off",
+      "implementation": "unsupported",
+      "platform_supported_profiles": {
+        "darwin": ["off"],
+        "linux": ["off"],
+        "wsl": ["off"],
+        "windows": ["off"]
+      },
+      "notes": "Grok Bot is a controller host port, not a dispatched CLI worker. Code workers keep their own adapter sandboxes."
+    },
+    "auto_approve_detection": {"probes": ["grok-bot-args-scan"], "strict_fail": true},
+    "secrets": [],
+    "irreversible_ops": ["git reset --hard", "force push", "rm -rf"]
+  },
+  "memory_backend": {
+    "canonical": "repo_files",
+    "repo_files": [".goal-flight/**"],
+    "host_native": {"role": "advisory", "backend": "Grok Bot session state"},
+    "mirror_writeback": false,
+    "source_epoch": "goal-flight-0.5.0",
+    "snapshot_id": "grok-bot-host-adapter",
+    "migration_lock_required_for_writeback": true,
+    "drift_policy": "warn_and_prefer_repo"
+  },
+  "packaging": {
+    "checked_in_wrappers": ["configs/grok-bot/"],
+    "generated_outputs": ["dist/grok-bot/"],
+    "install_actions": [
+      {
+        "kind": "copy",
+        "source": "configs/grok-bot/skills/goal-flight/SKILL.md",
+        "target": "${GOALFLIGHT_GROK_BOT_WORKFLOWS}/goal-flight/SKILL.md",
+        "writes_repo": false,
+        "writes_user_config": true,
+        "user_gate": true,
+        "backup_path": "$XDG_STATE_HOME/goal-flight/setup-backups/grok-bot.json",
+        "rollback": "restore_backup",
+        "destinations": ["grok-bot-workflows-controller"]
+      }
+    ],
+    "plugin_manifest": {"supported": false, "path": null, "api_status": "unsupported"},
+    "mcp": {"required": false, "servers": []},
+    "validation": ["json parse", "schema required groups", "candidate gate stays deny"]
+  },
+  "setup": {
+    "controller_destinations": [
+      {
+        "id": "grok-bot-workflows-controller",
+        "label": "Grok Bot workflows-library controller",
+        "role": "controller",
+        "surface": "desktop",
+        "default": true,
+        "probe_ids": [],
+        "install_action_sources": ["configs/grok-bot/skills/goal-flight/SKILL.md"],
+        "commands": ["./install.sh grok-bot", "./setup.sh --apply --yes --grok-bot"],
+        "paths": [
+          "/home/box/agent-data/workflows/goal-flight/SKILL.md",
+          "${GOALFLIGHT_GROK_BOT_WORKFLOWS}/goal-flight/SKILL.md"
+        ],
+        "requires_restart": false
+      }
+    ],
+    "worker_destinations": [],
+    "addons": [
+      {
+        "id": "gstack",
+        "label": "gstack skills",
+        "default": true,
+        "compatible_destination_ids": ["grok-bot-workflows-controller"],
+        "install_mode": "init_self_check",
+        "commands": ["test -d ~/.gstack/repos/gstack/.agents/skills"],
+        "paths": ["~/.gstack"]
+      },
+      {
+        "id": "gstack-browser",
+        "label": "gstack headless browser (web-QA)",
+        "default": false,
+        "compatible_destination_ids": ["grok-bot-workflows-controller"],
+        "install_mode": "init_self_check",
+        "commands": ["test -x \"${GSTACK_BROWSE_BIN:-}\" || test -x ~/.claude/skills/gstack/browse/dist/browse || test -x ~/.gstack/repos/gstack/browse/dist/browse"],
+        "paths": [
+          "~/.claude/skills/gstack/browse/dist/browse",
+          "~/.gstack/repos/gstack/browse/dist/browse",
+          "~/.claude/skills/gstack/qa",
+          "~/.gstack/repos/gstack/qa"
+        ]
+      },
+      {
+        "id": "autoreview",
+        "label": "autoreview chunk review",
+        "default": true,
+        "compatible_destination_ids": ["grok-bot-workflows-controller"],
+        "install_mode": "init_self_check",
+        "commands": ["test -x scripts/autoreview.sh"],
+        "paths": ["scripts/autoreview.sh", "scripts/autoreview_claude_acp", "~/.cursor/skills/autoreview"]
+      }
+    ]
+  },
+  "discovery": {
+    "budget": {
+      "max_path_probes": 4,
+      "max_version_probes": 0,
+      "max_help_probes": 0,
+      "max_ms_per_probe": 6000,
+      "max_total_ms_per_agent": 20000,
+      "max_total_ms_all_agents": 90000,
+      "max_stdout_bytes_per_probe": 4096,
+      "max_stderr_bytes_per_probe": 4096,
+      "network_default": "deny",
+      "model_consuming": "forbidden"
+    },
+    "probes": [
+      {
+        "id": "grok-bot-workflows-library",
+        "class": "path",
+        "argv": [
+          "sh",
+          "-lc",
+          "root=${GOALFLIGHT_GROK_BOT_WORKFLOWS:-/home/box/agent-data/workflows}; test -d \"$root\" && printf '%s' \"$root\""
+        ],
+        "safe_for_setup": true,
+        "network": false,
+        "model_consuming": false,
+        "env_scrub": true
+      }
+    ]
+  },
+  "status_contract": {
+    "schema": "goalflight.acp-run.v1",
+    "liveness_profile": "remote_api",
+    "heartbeat_required": true,
+    "dispatcher_owns_heartbeat": true,
+    "status_file": ".goal-flight/status/<dispatch_id>.json",
+    "transport_instance_id": "grok-bot:<pid>:<dispatch_id>",
+    "seq": "monotonic integer",
+    "parser_type": "plugin",
+    "marker_namespace": "goalflight:<dispatch_id>:<transport>:<seq>",
+    "stale_after_s": 180,
+    "terminal_states": ["complete", "failed", "blocked", "wedged"]
+  },
+  "host_projection": {
+    "controller_only": true,
+    "not_a_grok_cli_replacement": true,
+    "skill_pin": "${GOALFLIGHT_ROOT:-~/.goal-flight/skill}",
+    "workflows_library": {
+      "verified_bot_box": "/home/box/agent-data/workflows/goal-flight/SKILL.md",
+      "override_env": "GOALFLIGHT_GROK_BOT_WORKFLOWS",
+      "notes": "Verified on the Grok Bot box as the user-created workflows library. Mac-side library roots are not a second invented default; set the override when install does not run on that box."
+    },
+    "wake": {
+      "path": "goalflight_messages.py listen",
+      "not": "supervise persistent stdout monitor",
+      "notes": "Grok Bot has no persistent: true stdout monitor. Use the portable listen doorbell (exit-as-wake). Background Task completion may revive the parent for recon; that is not a mail doorbell."
+    },
+    "same_provider_policy_notes": "forbid_self_review: a Grok Bot controller must not Type-1-review a grok-code worker. Independent engine (codex/gstack) remains the default.",
+    "model_notes": "No model id is pinned. Do not reintroduce a pin here."
+  }
+}

--- a/adapters/grok-bot.json
+++ b/adapters/grok-bot.json
@@ -320,6 +320,11 @@
       "advisory_host_memory": ["profile", "update_state", "routines"],
       "canonical_memory": "repo_files",
       "resume_wake": "skip commands/resume.md STEP 1.5 supervise; arm portable listen pool",
+      "operator_is_compaction_mailman": false,
+      "operator_wake_hygiene": "re-arm listen after host update or token-pause",
+      "operator_signal": "roster wake unarmed (wake_armed/wake_covered/supervisor)",
+      "no_second_reminder_channel": true,
+      "token_pause_or_update": "listen exit 5 or reaped tracked tasks; next user message or next 15-minute arm/timeout claims and re-arms",
       "not": [
         "invent a compact UI",
         "ask the user to compact",

--- a/adapters/grok-bot.json
+++ b/adapters/grok-bot.json
@@ -51,7 +51,7 @@
         "safe probes only"
       ]
     },
-    "read_file": {"host_tools": ["workspace file read"], "constraints": ["workspace reads only"]},
+    "read_file": {"host_tools": ["workspace file read"], "constraints": ["executor Reads of the Mac checkout go through machineId; do not assume box-local files"]},
     "write_file": {"host_tools": ["workspace edit"], "constraints": ["authorized edit scope only"]},
     "search": {"host_tools": ["workspace search"], "constraints": ["filtered search"]},
     "delegate": {
@@ -64,7 +64,8 @@
         "choose Executor vs CLI from token/budget and task shape; do not treat Executor as last-resort",
         "CLI code workers: --agent codex, grok-code, or moonshot (kimi3 via adapters/moonshot.json; no kimi3 agent id)",
         "independent reviews: --agent moonshot or --agent codex; forbid_self_review blocks Type-1 review of grok-code",
-        "Cloud Agents are optional GitHub-branch/PR workers only, never the default"
+        "Cloud Agents are optional GitHub-branch/PR workers only, never the default",
+        "judgment-bearing Task prompts open with protocols/subagent-preamble.md; apply worker-context-package.md only when the lane is triggered; executors start blank on the Grok Bot box and must name machineId plus Mac absolute paths for every Read/Shell"
       ]
     },
     "ask_user": {"host_tools": ["USER-NEED marker"], "constraints": ["block on ambiguity"]},
@@ -307,7 +308,19 @@
         "independent": ["moonshot", "codex"],
         "notes": "kimi3 reviews use --agent moonshot. Do not invent a kimi3 agent id."
       },
-      "host_native_executor": ["recon", "synthesis", "mail", "status", "planning"]
+      "host_native_executor": ["recon", "synthesis", "mail", "status", "planning"],
+      "executor_context_package": {
+        "reuse": ["protocols/subagent-preamble.md"],
+        "triggered_lane_package": "protocols/worker-context-package.md",
+        "cli_prompt": "compose five-layer --prompt-file via prompts/dispatch-wrapper.md; paste or cite that composed body in the Task prompt, not the recipe file",
+        "orientation": "docs-private/rag/ORIENTATION.md when present (orientation only)",
+        "default_computer": "Grok Bot box",
+        "work_computer": "user registered computer via machineId",
+        "mac_path_prefix": "/Users/simonrowland/Repos/",
+        "machine_pin_applies_to": "every Read/Shell including preamble orientation reads",
+        "no_clone_onto_box": true,
+        "no_parallel_package_format": true
+      }
     }
   }
 }

--- a/configs/grok-bot/skills/goal-flight/SKILL.md
+++ b/configs/grok-bot/skills/goal-flight/SKILL.md
@@ -43,25 +43,41 @@ installed wrapper copy has drifted from that pin; resync with
 
 ## Dispatch and workers
 
-Dispatch CLI workers with the existing scripts (`goalflight_dispatch.py` to the
-codex / grok CLI / cursor / claude adapters). Do not add a parallel task store.
+Grok Bot Executors (Task / executor subagents) are a **first-class** dispatch
+target on this host. Do not copy the Claude-host rule that treats the host
+Agent as a last-resort code executor. That rule stays in the portable
+`SKILL.md` for Claude Code only.
 
-Run those CLI workers on the user's registered computer (the Mac checkout),
-not on the Grok Bot box, and not by cloning the repository onto the box. Grok
-Bot Shell can target that machine with a `machineId`.
+Choose the lane from token/budget (rate pressure, provider spend, session
+limits) and from the task (code vs review vs recon vs planning). Both lanes
+are valid:
 
-- Grok Bot Task / executor subagents are recon, analysis, and review only.
-  They are not code executors. Same rule as the host Agent in the portable core.
-- Grok Bot Cloud Agents are an optional extra worker for GitHub-branch / PR
-  chunks only. They are never the default for a local scientific-coding project.
-- Independent review stays on a different engine (codex / gstack). This host
-  inherits `forbid_self_review`: a Grok Bot controller must not Type-1-review a
-  `grok-code` worker.
-- Do not pin Grok model ids.
+- existing CLI workers via `goalflight_dispatch.py` on the user's registered
+  computer (the Mac checkout), targeted with Grok Bot Shell `machineId`
+- Grok Bot Task / executor subagents (host `delegate` surface)
+
+Do not add a parallel task store. Do not clone the repository onto the Grok
+Bot box. Do not pin Grok model ids.
+
+### Grok Bot routing
+
+| Task | Prefer when capacity is healthy | Alternate / host-native |
+|---|---|---|
+| Code-writing | CLI: `--agent codex`, `--agent grok-code`, or `--agent moonshot` (Kimi Code / kimi3; do not invent a `kimi3` agent id) | Grok Bot Executor when that lane is cheaper or the only one with budget; also for host-native chunks (recon, synthesis, mail, status) |
+| Reviews | Independent CLI: `--agent moonshot` (kimi3) or `--agent codex` | gstack `/review` on an independent engine |
+| Research / web search | `--agent grok-research` (read-only CLI) | controller-direct or Executor recon |
+| Planning / status / mail | Grok Bot Executor or controller-direct | CLI only when the chunk is a large write |
+
+`forbid_self_review` still applies: a Grok Bot controller must not Type-1-review
+a `grok-code` worker. Use moonshot/kimi3 or codex (or gstack) as the
+independent reviewer.
+
+Grok Bot Cloud Agents remain an optional extra worker for GitHub-branch / PR
+chunks only. They are never the default for a local scientific-coding project.
 
 Stamp `--controller-label --controller-pid --controller-session-id` on every
-dispatch. Claim a Grok Bot controller label of your own. Never steal a live
-lease that belongs to another controller.
+`goalflight_dispatch.py` launch. Claim a Grok Bot controller label of your own.
+Never steal a live lease that belongs to another controller.
 
 ## Multi-controller etiquette
 
@@ -91,8 +107,9 @@ On each ring (exit 0), process reported or authoritative mail, then restore
 listen depth. Five-controller setups still use `post --to-controller` plus that
 listen pool.
 
-Grok Bot may revive the parent when a background Task finishes. That is useful
-for executor recon. It is not a substitute for listen doorbells.
+Grok Bot may revive the parent when a background Task / Executor finishes.
+That is useful for host-native Executor work. It is not a substitute for
+listen doorbells.
 
 ## Setup
 

--- a/configs/grok-bot/skills/goal-flight/SKILL.md
+++ b/configs/grok-bot/skills/goal-flight/SKILL.md
@@ -40,6 +40,10 @@ installed wrapper copy has drifted from that pin; resync with
 - Treat Grok Bot session state, named-teammate memory, and host config as advisory.
 - Do not rewrite the root `SKILL.md` during setup. Setup registers this wrapper
   only.
+- Grok Bot Task / executor workers start blank (no chat, memory, SKILL.md, or
+  this conversation). Every judgment-bearing Task prompt reuses the Claude
+  host-subagent pin — do not invent a parallel package. See Executor context
+  package below.
 - Claim controller label `goalflight-grokbot` and stamp that claimed label
   on every `goalflight_dispatch.py` launch. Never steal a live lease.
 - Wake on worker terminals (`!COMPLETE` is the success marker) through the
@@ -94,6 +98,47 @@ Stamp `--controller-label <claimed-label> --controller-pid
 claimed label is `goalflight-grokbot` unless this controller already
 joined under another unused slug. Never steal a live lease that belongs
 to another controller.
+
+## Executor context package
+
+Grok Bot Task / executor subagents start **blank**. They have no chat
+history, no memory, no installed SKILL.md, and none of this conversation.
+Reuse the existing Claude host-subagent pin. Do not invent a parallel
+package format and do not add a grok-executor template (Cursor / Grok CLI
+wrappers do not have one).
+
+CLI workers (`--agent codex`, `grok-code`, `moonshot`, …) keep the
+existing five-layer `--prompt-file` dispatch (compose via
+`prompts/dispatch-wrapper.md`; do not paste that recipe file into a Task).
+Executors receive **that same composed prompt-file body** in the Task
+prompt (paste it, or cite its stable Mac path as the `--prompt-file`
+equivalent).
+
+Compose every judgment-bearing grok-executor Task prompt in this order:
+
+1. **Open** with `protocols/subagent-preamble.md` verbatim. Fill only the
+   two slots: repository path and north star. The repository path is the
+   Mac checkout, e.g. `/Users/simonrowland/Repos/<project>`.
+2. **Grok-bot-only pin** (the only new clause), immediately after the
+   preamble: executors default to the Grok Bot computer, **not** the
+   user's Mac. Name `machineId` / "the user's registered computer" and
+   absolute paths under `/Users/simonrowland/Repos/...`. Every Read and
+   Shell in this Task — including the preamble's AGENTS.md /
+   ORIENTATION.md reads — uses `machineId`. Do not clone the repo onto
+   the box.
+3. **Always** pointer to `docs-private/rag/ORIENTATION.md` when that file
+   exists (orientation only; never scope expansion). The preamble already
+   carries this pointer; keep it.
+4. **If the lane is triggered**, apply `protocols/worker-context-package.md`
+   in full: verbatim brief prepend (never link-instead-of-paste), quoted
+   ground-truth spec, named guard tests, standing re-read. Then the
+   `--prompt-file` equivalent: the same five-layer body CLI would get.
+   Citing a Mac path is allowed for that composed prompt file; it does
+   not replace the verbatim brief or quoted spec.
+
+Mechanical Task prompts may carry the preamble harmlessly. Judgment-bearing
+prompts (interpret evidence, review, compare designs, tradeoffs, or write
+code against a spec) are not optional.
 
 ## Multi-controller etiquette
 

--- a/configs/grok-bot/skills/goal-flight/SKILL.md
+++ b/configs/grok-bot/skills/goal-flight/SKILL.md
@@ -166,10 +166,17 @@ controller joining that project must:
 - send merge-request mail; leave origin push to the project's integrator
 - never steal those existing leases
 
-SendToAgent / named teammate pings may wake another Grok Bot controller that
-shares the project. They are not the work plane. Controller-mail remains
-`goalflight_messages.py`: leases, journal, `post --to-controller`,
-merge-request / patch. Do not replace the journal with SendToAgent.
+Inter-controller traffic is **only**
+`goalflight_messages.py post --to-controller`. This controller joins that
+journal. Do not ask the user to paste mail, and do not ask them to tell
+another session to check mail. The operator is the former mailman.
+
+SendToAgent (Grok Bot teammate DMs) is an optional extra ping among
+grok-bot agents. It is never the work inbox and never the bridge to
+Claude `battery-*` controllers. Do not replace the journal with
+SendToAgent.
+
+Deafness is re-arm listen, not user-as-mailman.
 
 ## Wake path
 

--- a/configs/grok-bot/skills/goal-flight/SKILL.md
+++ b/configs/grok-bot/skills/goal-flight/SKILL.md
@@ -40,14 +40,20 @@ installed wrapper copy has drifted from that pin; resync with
 - Treat Grok Bot session state, named-teammate memory, and host config as advisory.
 - Do not rewrite the root `SKILL.md` during setup. Setup registers this wrapper
   only.
-- Wake on worker terminals through the existing journal doorbell. Arm a tracked
-  `goalflight_messages.py listen --report-pending` on the user's Mac (project
-  root + `--controller-label`); never detach it. On ring, `relay --drain`, act,
-  re-arm. Do not invent a second event bus, a Settings monitor widget, or a
-  Grok Bot-native mail transport. Do not arm unbounded `supervise` as a
-  background shell expecting per-line wakes — this host only notifies on job
-  completion. Missed wake is latency: resume still pulls status, task next, and
-  `relay --new`. See Wake path below.
+- Claim controller label `goalflight-grokbot` and stamp that claimed label
+  on every `goalflight_dispatch.py` launch. Never steal a live lease.
+- Wake on worker terminals (`!COMPLETE` is the success marker) through the
+  existing journal doorbell. Canonical arm is one tracked listen on the
+  user's Mac: `listen --report-pending --timeout-s 900 --controller-label
+  goalflight-grokbot`. The 900s quiet timeout is this host's frontier ping
+  (anti-stall), not Claude's 120s follow-stream heartbeat. Optional full
+  pool (depth 4): 900s on one slot only; others `--timeout-s 0`. On ring,
+  `relay --drain`, act, re-arm. On timeout (exit 1), pull status + task
+  next, then re-arm. Never detach. Do not invent a second event bus, a
+  Settings monitor widget, or a Grok Bot-native mail transport. Do not arm
+  unbounded `supervise` as a background shell. Missed wake is latency:
+  resume still pulls status, task next, and `relay --new`. See Wake path
+  below.
 
 ## Dispatch and workers
 
@@ -83,9 +89,11 @@ independent reviewer.
 Grok Bot Cloud Agents remain an optional extra worker for GitHub-branch / PR
 chunks only. They are never the default for a local scientific-coding project.
 
-Stamp `--controller-label --controller-pid --controller-session-id` on every
-`goalflight_dispatch.py` launch. Claim a Grok Bot controller label of your own.
-Never steal a live lease that belongs to another controller.
+Stamp `--controller-label <claimed-label> --controller-pid
+--controller-session-id` on every `goalflight_dispatch.py` launch. The
+claimed label is `goalflight-grokbot` unless this controller already
+joined under another unused slug. Never steal a live lease that belongs
+to another controller.
 
 ## Multi-controller etiquette
 
@@ -95,7 +103,7 @@ example uses integrator / engine / bugs / webui / perf labels), a Grok Bot
 controller joining that project must:
 
 - read the project's `docs-private/MULTI-CONTROLLER-ETIQUETTE.md` when present
-- claim a new label and its own worktree / branch
+- claim `goalflight-grokbot` (or another unused label) and its own worktree / branch
 - send merge-request mail; leave origin push to the project's integrator
 - never steal those existing leases
 
@@ -108,10 +116,9 @@ merge-request / patch. Do not replace the journal with SendToAgent.
 
 Journal mail is durable truth. Worker terminals are the existing markers in
 `protocols/worker-markers.md`: `!COMPLETE` / `!READY` / `!FAILED` /
-`!BLOCKED` / `!USER-NEED` (leading `!` optional). There is no `!FINISHED`;
-if someone says FINISHED, treat it as `!COMPLETE`. The watcher already
-harvests those into the terminal-outbox / controller mail. Do not invent a
-second event bus.
+`!BLOCKED` / `!USER-NEED` (leading `!` optional). `!COMPLETE` is the
+success terminal. The watcher already harvests those into the
+terminal-outbox / controller mail. Do not invent a second event bus.
 
 Grok Bot notifies on **job completion** (Task / executor or a tracked Shell
 exits and revives the parent chat). That is the same contract as
@@ -119,27 +126,40 @@ exits and revives the parent chat). That is the same contract as
 per-line `supervise` / `follow`. There is no Settings "monitor widget"; the
 running background task / subagent card is the UI.
 
-Canonical arm — tracked `listen --report-pending` on the **user's Mac**
-(project-root + `--controller-label`), never detached (`nohup` → listen
-exit 4):
+This host uses the portable listen / heartbeat process pool. The frontier
+ping is `listen --timeout-s 900` (15 minutes of quiet), so the controller
+is reminded of the task frontier and does not stall. That is **not**
+Claude's follow-stream heartbeat (120s; the stream range is 60–300s and
+would spam Grok Bot turns). Do not change the global `supervise` / `follow`
+cadence for this host; 900s is a wrapper-local default on the listen arm.
+
+Canonical arm — one tracked listen on the **user's Mac**, label
+`goalflight-grokbot`, never detached (`nohup` → listen exit 4):
 
 ```shell
 python3 <skill-root>/scripts/goalflight_messages.py listen \
   --project-root "$PWD" \
-  --controller-label "$GOALFLIGHT_CONTROLLER_LABEL" \
-  --report-pending
+  --controller-label goalflight-grokbot \
+  --report-pending \
+  --timeout-s 900
 ```
 
-On ring (exit 0): `relay --drain`, act, re-arm. The portable four-listen
-pool is full depth; one listen is the MVP. Branch on listen exit codes
-(`protocols/controller-mail.md`); exit 5 is did-not-arm (do not re-arm
+On ring (exit 0): `relay --drain`, act, re-arm. On timeout (exit 1): pull
+`goalflight_status.py` and `goalflight_task.py next`, then re-arm — that
+exit *is* the 15-minute frontier reminder. The portable four-listen pool
+is full depth; one listen is the MVP. If you arm more than one listen,
+put `--timeout-s 900` on a single slot (the frontier ping) and leave the
+others at `--timeout-s 0` so four quiet timeouts do not fire together.
+Branch on listen exit codes. Exit 1 on this host is the frontier
+reminder above (status + task next, re-arm), not the portable
+"re-arm only if coverage is still required" row. Codes 2–5 follow
+`protocols/controller-mail.md`; exit 5 is did-not-arm (do not re-arm
 that nonce).
 
 Do **not** arm unbounded `supervise` as a Grok Bot background shell and
-expect per-line wakes. Supervise heartbeats (~120s) would never complete
-or, if every line were awaited, spam turns. A helper, if added, must wrap
-`listen` or exit on the first actionable event (ignore heartbeat /
-frontier). A same-turn regex-wait on a live `supervise` process is a
+expect per-line wakes. A helper, if added, must wrap `listen` or exit on
+the first actionable event (ignore stream heartbeat / frontier
+keepalives). A same-turn regex-wait on a live `supervise` process is a
 same-turn block, not a session-life monitor; do not use it as the default.
 
 Missed wake is latency, not data loss. Resume still pulls

--- a/configs/grok-bot/skills/goal-flight/SKILL.md
+++ b/configs/grok-bot/skills/goal-flight/SKILL.md
@@ -40,6 +40,14 @@ installed wrapper copy has drifted from that pin; resync with
 - Treat Grok Bot session state, named-teammate memory, and host config as advisory.
 - Do not rewrite the root `SKILL.md` during setup. Setup registers this wrapper
   only.
+- Wake on worker terminals through the existing journal doorbell. Arm a tracked
+  `goalflight_messages.py listen --report-pending` on the user's Mac (project
+  root + `--controller-label`); never detach it. On ring, `relay --drain`, act,
+  re-arm. Do not invent a second event bus, a Settings monitor widget, or a
+  Grok Bot-native mail transport. Do not arm unbounded `supervise` as a
+  background shell expecting per-line wakes — this host only notifies on job
+  completion. Missed wake is latency: resume still pulls status, task next, and
+  `relay --new`. See Wake path below.
 
 ## Dispatch and workers
 
@@ -98,18 +106,44 @@ merge-request / patch. Do not replace the journal with SendToAgent.
 
 ## Wake path
 
-`supervise` needs a host monitor where each flushed stdout line is a controller
-notification, unbounded, `persistent: true`. Grok Bot does not have that
-monitor.
+Journal mail is durable truth. Worker terminals are the existing markers in
+`protocols/worker-markers.md`: `!COMPLETE` / `!READY` / `!FAILED` /
+`!BLOCKED` / `!USER-NEED` (leading `!` optional). There is no `!FINISHED`;
+if someone says FINISHED, treat it as `!COMPLETE`. The watcher already
+harvests those into the terminal-outbox / controller mail. Do not invent a
+second event bus.
 
-Use the portable `goalflight_messages.py listen` doorbell fallback (exit-as-wake).
-On each ring (exit 0), process reported or authoritative mail, then restore
-listen depth. Five-controller setups still use `post --to-controller` plus that
-listen pool.
+Grok Bot notifies on **job completion** (Task / executor or a tracked Shell
+exits and revives the parent chat). That is the same contract as
+`goalflight_messages.py listen` (exit-as-wake), not Claude's persistent
+per-line `supervise` / `follow`. There is no Settings "monitor widget"; the
+running background task / subagent card is the UI.
 
-Grok Bot may revive the parent when a background Task / Executor finishes.
-That is useful for host-native Executor work. It is not a substitute for
-listen doorbells.
+Canonical arm — tracked `listen --report-pending` on the **user's Mac**
+(project-root + `--controller-label`), never detached (`nohup` → listen
+exit 4):
+
+```shell
+python3 <skill-root>/scripts/goalflight_messages.py listen \
+  --project-root "$PWD" \
+  --controller-label "$GOALFLIGHT_CONTROLLER_LABEL" \
+  --report-pending
+```
+
+On ring (exit 0): `relay --drain`, act, re-arm. The portable four-listen
+pool is full depth; one listen is the MVP. Branch on listen exit codes
+(`protocols/controller-mail.md`); exit 5 is did-not-arm (do not re-arm
+that nonce).
+
+Do **not** arm unbounded `supervise` as a Grok Bot background shell and
+expect per-line wakes. Supervise heartbeats (~120s) would never complete
+or, if every line were awaited, spam turns. A helper, if added, must wrap
+`listen` or exit on the first actionable event (ignore heartbeat /
+frontier). A same-turn regex-wait on a live `supervise` process is a
+same-turn block, not a session-life monitor; do not use it as the default.
+
+Missed wake is latency, not data loss. Resume still pulls
+`goalflight_status.py`, `goalflight_task.py next`, and `relay --new`.
 
 ## Setup
 

--- a/configs/grok-bot/skills/goal-flight/SKILL.md
+++ b/configs/grok-bot/skills/goal-flight/SKILL.md
@@ -12,6 +12,12 @@ Grok Bot is a host projection over the portable Goal Flight core. It is not a
 rewrite of that core and it does not replace the Grok CLI adapter
 (`adapters/grok.json`, `grok agent stdio`).
 
+## Freshness (always loaded)
+
+Disk-read repository `SKILL.md` Hard Invariants. If you cannot quote them
+from that read, you are stale: run Compaction resume before acting. This
+rule cannot live only in compacted chat or a summarized SKILL.md.
+
 ## Load Order
 
 1. Read the repository `AGENTS.md` first when present.
@@ -47,18 +53,22 @@ installed wrapper copy has drifted from that pin; resync with
 - Claim controller label `goalflight-grokbot` and stamp that claimed label
   on every `goalflight_dispatch.py` launch. Never steal a live lease.
 - Wake on worker terminals (`!COMPLETE` is the success marker) through the
-  existing journal doorbell. Canonical arm is one tracked listen on the
-  user's Mac: `listen --report-pending --timeout-s 900 --controller-label
-  goalflight-grokbot`. The 900s quiet timeout is this host's frontier ping
-  (anti-stall), not Claude's 120s follow-stream heartbeat. Optional full
-  pool (depth 4): 900s on one slot only; others `--timeout-s 0`. On ring,
-  `relay --drain`, act, re-arm. On timeout (exit 1), run the directed-compact
-  write (`protocols/state-handoff.md` Before compact or sleep), pull status
-  + task next, then re-arm. Never detach. Do not invent a second event bus,
-  a Settings monitor widget, a compact UI, or a Grok Bot-native mail
-  transport. Do not arm unbounded `supervise` as a background shell.
-  Missed wake is latency: resume still pulls status, task next, and
-  `relay --new`. See Wake path and Compaction below.
+  existing journal doorbell. Canonical arm is one tracked
+  `goalflight_grok_bot_listen.py --report-pending --timeout-s 900
+  --controller-label goalflight-grokbot` on the user's Mac (that helper
+  wraps `listen --report-pending` and prints the quote-check banner). The
+  900s quiet timeout is this host's frontier ping (anti-stall), not
+  Claude's 120s follow-stream heartbeat. Optional full pool (depth 4):
+  900s on one slot only; others `--timeout-s 0`. Every ring or timeout is
+  a mini-resume: drain if it rang, flush RESUME-NOTES (`state-handoff.md`
+  Before compact or sleep), quote-check Hard Invariants from disk, re-arm,
+  `goalflight_task.py next`. Never detach.
+  Do not invent a second event bus, a Settings monitor widget, a compact
+  UI, a context-consumption meter, or a Grok Bot-native mail transport.
+  Do not port Claude PostToolUse / SessionStart hooks. Do not arm
+  unbounded `supervise` as a background shell. Missed wake is latency:
+  resume still pulls status, task next, and `relay --new`. See Wake path
+  and Compaction below.
 
 ## Dispatch and workers
 
@@ -179,30 +189,31 @@ Claude's follow-stream heartbeat (120s; the stream range is 60–300s and
 would spam Grok Bot turns). Do not change the global `supervise` / `follow`
 cadence for this host; 900s is a wrapper-local default on the listen arm.
 
-Canonical arm — one tracked listen on the **user's Mac**, label
-`goalflight-grokbot`, never detached (`nohup` → listen exit 4):
+Canonical arm — one tracked `goalflight_grok_bot_listen.py` on the
+**user's Mac**, label `goalflight-grokbot`, never detached (`nohup` →
+listen exit 4). That helper wraps `listen` and prints the quote-check
+banner on every exit (ring or timeout). The doorbell is outside the chat.
 
 ```shell
-python3 <skill-root>/scripts/goalflight_messages.py listen \
+python3 <skill-root>/scripts/goalflight_grok_bot_listen.py \
   --project-root "$PWD" \
   --controller-label goalflight-grokbot \
   --report-pending \
   --timeout-s 900
 ```
 
-On ring (exit 0): `relay --drain`, act, re-arm. On timeout (exit 1): run
-the directed-compact write (Compaction below), pull `goalflight_status.py`
-and `goalflight_task.py next`, then re-arm — that exit *is* the 15-minute
-frontier reminder and the last reliable moment before an unannounced host
-summary. The portable four-listen pool
-is full depth; one listen is the MVP. If you arm more than one listen,
-put `--timeout-s 900` on a single slot (the frontier ping) and leave the
-others at `--timeout-s 0` so four quiet timeouts do not fire together.
-Branch on listen exit codes. Exit 1 on this host is the frontier
-reminder above (handoff write + status + task next, re-arm), not the
-portable "re-arm only if coverage is still required" row. Codes 2–5 follow
-`protocols/controller-mail.md`; exit 5 is did-not-arm (do not re-arm
-that nonce).
+Every ring (exit 0) or timeout (exit 1) is a **mini-resume**: drain if
+it rang (`relay --drain`, act), flush RESUME-NOTES (Compaction below),
+quote-check Hard Invariants from a fresh disk read, re-arm, then
+`goalflight_task.py next`. The 900s quiet timeout is this host's
+substitute for Claude's 80% context-meter hint. The portable four-listen
+pool is full depth; one listen is the MVP. If you arm more than one
+listen, put `--timeout-s 900` on a single slot (the frontier ping) and
+leave the others at `--timeout-s 0` so four quiet timeouts do not fire
+together. Branch on listen exit codes. Exit 1 on this host is the
+frontier reminder above, not the portable "re-arm only if coverage is
+still required" row. Codes 2–5 follow `protocols/controller-mail.md`;
+exit 5 is did-not-arm (do not re-arm that nonce).
 
 Do **not** arm unbounded `supervise` as a Grok Bot background shell and
 expect per-line wakes. A helper, if added, must wrap `listen` or exit on
@@ -214,6 +225,14 @@ Missed wake is latency, not data loss. Resume still pulls
 `goalflight_status.py`, `goalflight_task.py next`, and `relay --new`.
 
 ## Compaction
+
+Grok Bot = **autocompact + keep handoff current**. Do **not** port
+`scripts/hooks/goalflight-context-meter.sh` or Claude PostToolUse
+`additionalContext` 80/90/95% bands. That hook is Claude-Code-specific.
+Grok Bot has no PostToolUse `additionalContext` injection and no
+trustworthy window %. A fake meter is worse than none. Claude
+context-meter and SessionStart watchdog stay Claude-only. There is no
+SessionStart hook on grok-bot.
 
 Grok Bot has **no** controller-authored `/compact` and **no** keep-vs-toss
 prompt. The host may summarize the chat on its own. Do not invent a compact UI.
@@ -229,8 +248,25 @@ The directed-compact step on this host **is**
   deferred / held when relevant)
 - `goalflight_status.py`
 
-Write that on the 15-minute frontier heartbeat (listen exit 1) and
-before long waves. There is no warning before the host summarizes.
+The 15-minute listen timeout is the substitute for Claude's 80% hint.
+On **every** ring or timeout, flush that handoff, then quote-check. Also
+write before long waves. There is no warning before the host summarizes.
+
+The Hard Invariants quoting rule cannot live only in compacted SKILL.md.
+Externalize it:
+
+1. This wrapper's Freshness preamble (always loaded): disk-read SKILL.md
+   Hard Invariants; if you cannot quote them, stale → resume before acting.
+2. Listen/heartbeat stdout banner (doorbell is outside the chat):
+   `goalflight_grok_bot_listen.py` prints
+   `QUOTE-CHECK: disk-read SKILL.md Hard Invariants; if you cannot quote them, stale — resume before acting.`
+   on every listen exit.
+3. Optional operator-side Grok Bot profile sentence:
+   `On every Goal Flight listen exit, disk-read SKILL.md Hard Invariants; if you cannot quote them, resume before acting.`
+
+Every 15-minute wake is a mini-resume: drain if it rang, flush
+RESUME-NOTES, quote-check from disk, re-arm doorbells,
+`goalflight_task.py next`.
 
 Resume reload and rebuild are unchanged. Chat summaries are hints, not
 substitutes. Grok Bot profile, `update_state` memory, and routines may

--- a/configs/grok-bot/skills/goal-flight/SKILL.md
+++ b/configs/grok-bot/skills/goal-flight/SKILL.md
@@ -67,8 +67,11 @@ installed wrapper copy has drifted from that pin; resync with
   UI, a context-consumption meter, or a Grok Bot-native mail transport.
   Do not port Claude PostToolUse / SessionStart hooks. Do not arm
   unbounded `supervise` as a background shell. Missed wake is latency:
-  resume still pulls status, task next, and `relay --new`. See Wake path
-  and Compaction below.
+  resume still pulls status, task next, and `relay --new`. The operator
+  is not the compaction mailman. The one operator wake-hygiene job is
+  re-arming listen doorbells after a host update or token-pause, surfaced
+  as roster `wake unarmed` — not a second reminder channel. See
+  Compaction and Operator role in `docs/hosts/grok-bot.md`.
 
 ## Dispatch and workers
 
@@ -283,6 +286,13 @@ repository `SKILL.md` → `commands/resume.md`. Then:
 3. store baseline (`goalflight_status.py` + `goalflight_task.py list`)
 4. newest RESUME-NOTES
 5. `goalflight_task.py next`
+
+The operator is not the compaction mailman. After a host update or
+token-pause, listen may exit 5 (dead lease nonce) or tracked tasks may
+be reaped. The next user message or next 15-minute arm/timeout should
+claim and re-arm. Surface a deaf controller as roster `wake unarmed`
+(`wake_armed` / `wake_covered` / `supervisor` absent). Do not invent a
+second reminder channel.
 
 ## Setup
 

--- a/configs/grok-bot/skills/goal-flight/SKILL.md
+++ b/configs/grok-bot/skills/goal-flight/SKILL.md
@@ -52,12 +52,13 @@ installed wrapper copy has drifted from that pin; resync with
   goalflight-grokbot`. The 900s quiet timeout is this host's frontier ping
   (anti-stall), not Claude's 120s follow-stream heartbeat. Optional full
   pool (depth 4): 900s on one slot only; others `--timeout-s 0`. On ring,
-  `relay --drain`, act, re-arm. On timeout (exit 1), pull status + task
-  next, then re-arm. Never detach. Do not invent a second event bus, a
-  Settings monitor widget, or a Grok Bot-native mail transport. Do not arm
-  unbounded `supervise` as a background shell. Missed wake is latency:
-  resume still pulls status, task next, and `relay --new`. See Wake path
-  below.
+  `relay --drain`, act, re-arm. On timeout (exit 1), run the directed-compact
+  write (`protocols/state-handoff.md` Before compact or sleep), pull status
+  + task next, then re-arm. Never detach. Do not invent a second event bus,
+  a Settings monitor widget, a compact UI, or a Grok Bot-native mail
+  transport. Do not arm unbounded `supervise` as a background shell.
+  Missed wake is latency: resume still pulls status, task next, and
+  `relay --new`. See Wake path and Compaction below.
 
 ## Dispatch and workers
 
@@ -189,15 +190,17 @@ python3 <skill-root>/scripts/goalflight_messages.py listen \
   --timeout-s 900
 ```
 
-On ring (exit 0): `relay --drain`, act, re-arm. On timeout (exit 1): pull
-`goalflight_status.py` and `goalflight_task.py next`, then re-arm — that
-exit *is* the 15-minute frontier reminder. The portable four-listen pool
+On ring (exit 0): `relay --drain`, act, re-arm. On timeout (exit 1): run
+the directed-compact write (Compaction below), pull `goalflight_status.py`
+and `goalflight_task.py next`, then re-arm — that exit *is* the 15-minute
+frontier reminder and the last reliable moment before an unannounced host
+summary. The portable four-listen pool
 is full depth; one listen is the MVP. If you arm more than one listen,
 put `--timeout-s 900` on a single slot (the frontier ping) and leave the
 others at `--timeout-s 0` so four quiet timeouts do not fire together.
 Branch on listen exit codes. Exit 1 on this host is the frontier
-reminder above (status + task next, re-arm), not the portable
-"re-arm only if coverage is still required" row. Codes 2–5 follow
+reminder above (handoff write + status + task next, re-arm), not the
+portable "re-arm only if coverage is still required" row. Codes 2–5 follow
 `protocols/controller-mail.md`; exit 5 is did-not-arm (do not re-arm
 that nonce).
 
@@ -209,6 +212,41 @@ same-turn block, not a session-life monitor; do not use it as the default.
 
 Missed wake is latency, not data loss. Resume still pulls
 `goalflight_status.py`, `goalflight_task.py next`, and `relay --new`.
+
+## Compaction
+
+Grok Bot has **no** controller-authored `/compact` and **no** keep-vs-toss
+prompt. The host may summarize the chat on its own. Do not invent a compact UI.
+Do not ask the user to compact. Do not emulate Claude's compact prompt in chat.
+
+The directed-compact step on this host **is**
+`protocols/state-handoff.md` "Before compact or sleep":
+
+- update newest `docs-private/RESUME-NOTES-<YYYY-MM-DD>.md` with
+  ENVIRONMENT / IDEAS / DECISIONS / FACTS / CARRIERS only — no task tables,
+  dispatch codes, or next-task lists
+- store baseline via `goalflight_task.py list` (outstanding, plus
+  deferred / held when relevant)
+- `goalflight_status.py`
+
+Write that on the 15-minute frontier heartbeat (listen exit 1) and
+before long waves. There is no warning before the host summarizes.
+
+Resume reload and rebuild are unchanged. Chat summaries are hints, not
+substitutes. Grok Bot profile, `update_state` memory, and routines may
+persist across summaries; they are advisory. Repository files remain
+the canonical memory backend.
+
+If this controller cannot quote `SKILL.md` Hard Invariants from a
+**fresh disk read**, reload `AGENTS.md` → this grok-bot wrapper →
+repository `SKILL.md` → `commands/resume.md`. Then:
+
+1. `goalflight_session_status.py --text`
+2. **Skip** `commands/resume.md` STEP 1.5 (`supervise`). Arm listen
+   doorbells (portable pool) instead.
+3. store baseline (`goalflight_status.py` + `goalflight_task.py list`)
+4. newest RESUME-NOTES
+5. `goalflight_task.py next`
 
 ## Setup
 

--- a/configs/grok-bot/skills/goal-flight/SKILL.md
+++ b/configs/grok-bot/skills/goal-flight/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: goal-flight
+description: "Goal Flight orchestration for Grok Bot: plan, dispatch, review, recover, and resume long-running repository work from file-backed state."
+---
+
+# goal-flight
+
+Use this skill when a repository task needs durable planning, resumable work,
+worker dispatch, review flights, or handoff notes that survive context loss.
+
+Grok Bot is a host projection over the portable Goal Flight core. It is not a
+rewrite of that core and it does not replace the Grok CLI adapter
+(`adapters/grok.json`, `grok agent stdio`).
+
+## Load Order
+
+1. Read the repository `AGENTS.md` first when present.
+2. Read this Grok Bot host wrapper.
+3. Read the repository root `SKILL.md` as the canonical Goal Flight workflow.
+4. Read `protocols/guidance-extended.md` by default — non-frontier controllers
+   benefit from its worked examples and expanded rationale for the core's rules;
+   skip only when context is tight (the core alone is complete).
+5. Read the newest relevant `docs-private/RESUME-NOTES-*.md` only when the task
+   asks to resume prior Goal Flight work.
+
+## Skill pin
+
+Live controllers load the detached pin at `~/.goal-flight/skill/` (or
+`$GOALFLIGHT_ROOT`), not a live source checkout and not a clone on the Grok Bot
+box. Resolve `<skill-root>` before running scripts. Doctor warns when an
+installed wrapper copy has drifted from that pin; resync with
+`./install.sh grok-bot`.
+
+## Operating Rules
+
+- Treat repository Markdown plus Git as canonical state.
+- Keep queue, ledger, status, review, and handoff artifacts file-backed.
+- Facts come from `goalflight_status.py`, `goalflight_task.py list/next`, and
+  doctor. Conversation is not the backlog.
+- Treat Grok Bot session state, named-teammate memory, and host config as advisory.
+- Do not rewrite the root `SKILL.md` during setup. Setup registers this wrapper
+  only.
+
+## Dispatch and workers
+
+Dispatch CLI workers with the existing scripts (`goalflight_dispatch.py` to the
+codex / grok CLI / cursor / claude adapters). Do not add a parallel task store.
+
+Run those CLI workers on the user's registered computer (the Mac checkout),
+not on the Grok Bot box, and not by cloning the repository onto the box. Grok
+Bot Shell can target that machine with a `machineId`.
+
+- Grok Bot Task / executor subagents are recon, analysis, and review only.
+  They are not code executors. Same rule as the host Agent in the portable core.
+- Grok Bot Cloud Agents are an optional extra worker for GitHub-branch / PR
+  chunks only. They are never the default for a local scientific-coding project.
+- Independent review stays on a different engine (codex / gstack). This host
+  inherits `forbid_self_review`: a Grok Bot controller must not Type-1-review a
+  `grok-code` worker.
+- Do not pin Grok model ids.
+
+Stamp `--controller-label --controller-pid --controller-session-id` on every
+dispatch. Claim a Grok Bot controller label of your own. Never steal a live
+lease that belongs to another controller.
+
+## Multi-controller etiquette
+
+Five-controller layouts are a project convention, not a Goal Flight primitive.
+When a project already partitions lanes across named controllers (the live
+example uses integrator / engine / bugs / webui / perf labels), a Grok Bot
+controller joining that project must:
+
+- read the project's `docs-private/MULTI-CONTROLLER-ETIQUETTE.md` when present
+- claim a new label and its own worktree / branch
+- send merge-request mail; leave origin push to the project's integrator
+- never steal those existing leases
+
+SendToAgent / named teammate pings may wake another Grok Bot controller that
+shares the project. They are not the work plane. Controller-mail remains
+`goalflight_messages.py`: leases, journal, `post --to-controller`,
+merge-request / patch. Do not replace the journal with SendToAgent.
+
+## Wake path
+
+`supervise` needs a host monitor where each flushed stdout line is a controller
+notification, unbounded, `persistent: true`. Grok Bot does not have that
+monitor.
+
+Use the portable `goalflight_messages.py listen` doorbell fallback (exit-as-wake).
+On each ring (exit 0), process reported or authoritative mail, then restore
+listen depth. Five-controller setups still use `post --to-controller` plus that
+listen pool.
+
+Grok Bot may revive the parent when a background Task finishes. That is useful
+for executor recon. It is not a substitute for listen doorbells.
+
+## Setup
+
+From the cloned Goal Flight repository (or the pinned `~/.goal-flight/skill/`),
+run:
+
+```shell
+./setup.sh --grok-bot
+./setup.sh --apply --yes --grok-bot
+
+# one-shot; optional workflows-library root overrides the default
+./install.sh grok-bot
+./install.sh grok-bot /home/box/agent-data/workflows
+```
+
+The checked-in destination is the Grok Bot workflows library
+(`/home/box/agent-data/workflows/goal-flight/SKILL.md` on the bot machine).
+Override with `GOALFLIGHT_GROK_BOT_WORKFLOWS` when installing from a Mac
+checkout whose library root is different. This path is the least-wrong
+verified location; do not assume `~/.grok/skills/` (that is Grok CLI).

--- a/configs/grok-bot/skills/goal-flight/SKILL.md
+++ b/configs/grok-bot/skills/goal-flight/SKILL.md
@@ -33,9 +33,9 @@ rule cannot live only in compacted chat or a summarized SKILL.md.
 
 Live controllers load the detached pin at `~/.goal-flight/skill/` (or
 `$GOALFLIGHT_ROOT`), not a live source checkout and not a clone on the Grok Bot
-box. Resolve `<skill-root>` before running scripts. Doctor warns when an
-installed wrapper copy has drifted from that pin; resync with
-`./install.sh grok-bot`.
+box. Run scripts from that pin (`$GOALFLIGHT_ROOT/scripts` or
+`~/.goal-flight/skill/scripts`). Doctor warns when an installed wrapper copy
+has drifted from that pin; resync with `./install.sh grok-bot`.
 
 ## Operating Rules
 
@@ -107,11 +107,11 @@ independent reviewer.
 Grok Bot Cloud Agents remain an optional extra worker for GitHub-branch / PR
 chunks only. They are never the default for a local scientific-coding project.
 
-Stamp `--controller-label <claimed-label> --controller-pid
---controller-session-id` on every `goalflight_dispatch.py` launch. The
-claimed label is `goalflight-grokbot` unless this controller already
-joined under another unused slug. Never steal a live lease that belongs
-to another controller.
+Stamp `--controller-label <claimed-label> --controller-pid <pid>
+--controller-session-id <session-id>` on every `goalflight_dispatch.py`
+launch. The claimed label is `goalflight-grokbot` unless this controller
+already joined under another unused slug. Never steal a live lease that
+belongs to another controller.
 
 ## Executor context package
 
@@ -315,8 +315,16 @@ run:
 ./install.sh grok-bot /home/box/agent-data/workflows
 ```
 
+Bare `./install.sh grok-bot` applies the default gstack and autoreview addons; pass `--addons ''` to skip them.
+
 The checked-in destination is the Grok Bot workflows library
 (`/home/box/agent-data/workflows/goal-flight/SKILL.md` on the bot machine).
-Override with `GOALFLIGHT_GROK_BOT_WORKFLOWS` when installing from a Mac
-checkout whose library root is different. This path is the least-wrong
-verified location; do not assume `~/.grok/skills/` (that is Grok CLI).
+The default workflows root is that box path. From a Mac checkout pass
+`GOALFLIGHT_GROK_BOT_WORKFLOWS` or `./install.sh grok-bot <workflows-root>`.
+This repo does not invent a second Mac default library root. Do not assume
+`~/.grok/skills/` (that is Grok CLI).
+
+Doctor's `installed_skill_drift` for grok-bot hashes the box library (or
+the override). A Mac `doctor --project-root` without the override will
+not see `/home/box/...`; run the drift check on the box, or set
+`GOALFLIGHT_GROK_BOT_WORKFLOWS`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ root.
 | [architecture.md](architecture.md) | Portable core, runtime scripts, capacity, and validation boundaries |
 | [fleet.md](fleet.md) | Multi-node SSH fleet: bootstrap, dispatch, watch, reconcile |
 | [hosts/cursor.md](hosts/cursor.md) | Cursor install, MCP, and project-local setup |
+| [hosts/grok-bot.md](hosts/grok-bot.md) | Grok Bot controller wrapper, workflows-library install, and wake path |
 | [hosts/linux.md](hosts/linux.md) | Linux/WSL dispatch baseline, OS sandbox scope, and filesystem caveats |
 | [hosts/opencode.md](hosts/opencode.md) | OpenCode install, skills, MCP, and bash-tail workers |
 

--- a/docs/hosts/grok-bot.md
+++ b/docs/hosts/grok-bot.md
@@ -1,0 +1,113 @@
+# Grok Bot Notes
+
+Run from your Goal Flight clone or the pinned skill checkout (default
+`~/.goal-flight/skill/`; see README). Live controllers load that pin, not a
+live source tree.
+
+Grok Bot can run Goal Flight as an orchestrator through the installed skill
+wrapper. It does **not** replace the Grok CLI adapter (`adapters/grok.json`,
+`grok agent stdio`). CLI workers, the task store, and RAG stay on the portable
+core.
+
+One-shot install (wrapper copy into the Grok Bot workflows library):
+
+```bash
+./install.sh grok-bot
+# same as: ./setup.sh --apply --yes --grok-bot
+
+# when the workflows library root is not the bot-box default:
+./install.sh grok-bot /home/box/agent-data/workflows
+# or: GOALFLIGHT_GROK_BOT_WORKFLOWS=/path/to/workflows ./install.sh grok-bot
+```
+
+## Install destination (verified, with uncertainty)
+
+User-created Grok Bot skills live as `SKILL.md` under the Grok Bot workflows
+library. On the bot machine the verified path is:
+
+`/home/box/agent-data/workflows/<slug>/SKILL.md`
+
+Goal Flight copies this wrapper to
+`/home/box/agent-data/workflows/goal-flight/SKILL.md` unless
+`GOALFLIGHT_GROK_BOT_WORKFLOWS` (or the optional `install.sh grok-bot <root>`
+argument) points at a different library root.
+
+That box path is the least-wrong destination. It is **not** `~/.grok/skills/`
+(Grok CLI) and not `~/.cursor/skills/` (Cursor Agent). A Mac checkout that
+cannot see `/home/box/...` must pass the override; this repo does not invent a
+second default Mac path.
+
+Doctor's `installed_skill_drift` hashes the installed wrapper against
+`configs/grok-bot/skills/goal-flight/SKILL.md`. A WARN means resync with
+`./install.sh grok-bot`.
+
+## Resync after SKILL.md changes
+
+When the source Goal Flight repo's `SKILL.md` or tracked files under
+`commands/`, `protocols/`, `templates/`, or `adapters/` change, Grok Bot's
+installed copy is not auto-synced unless it is a symlink to the source repo.
+Resync from the source repo (or the pinned `~/.goal-flight/skill/`) with
+`./install.sh grok-bot`. To check for drift, run
+`python3 scripts/goalflight_doctor.py --project-root "$PWD" --json` and inspect
+`installed_skill_drift`; text mode prints `installed_skill_md_hash` WARNs.
+
+## How a Grok Bot controller operates
+
+Load order: `AGENTS.md` → this host wrapper → repository `SKILL.md` →
+`protocols/guidance-extended.md` by default (non-frontier) → newest
+`docs-private/RESUME-NOTES-*.md` when resuming.
+
+- Facts come from `goalflight_status.py`, `goalflight_task.py list/next`, and
+  doctor. Conversation is not the backlog.
+- Dispatch CLI workers on the user's registered computer (the Mac checkout)
+  via Grok Bot Shell with a `machineId`. Do not spawn workers on the Grok Bot
+  box and do not clone the repo onto the box.
+- Wrap the existing CLIs: `goalflight_dispatch.py`, `goalflight_messages.py`,
+  `goalflight_task.py`, status, doctor. Do not add a parallel store.
+- Grok Bot Task / executor subagents = recon / analysis / review only.
+- Grok Bot Cloud Agents = optional extra worker for GitHub-branch / PR chunks
+  only; never the default for a local scientific-coding project.
+- Same-provider review is `forbid_self_review`. A Grok Bot controller must not
+  Type-1-review a `grok-code` worker. Independent engine (codex / gstack)
+  remains the default. Do not pin Grok model ids.
+
+## Wake path
+
+`supervise` needs a host monitor where each flushed stdout line is a
+controller notification, unbounded, `persistent: true`. Grok Bot does not
+have Claude Code's persistent stdout monitor.
+
+Documented wake path: the portable `goalflight_messages.py listen` doorbell
+(exit-as-wake). On each ring, process mail, then restore listen depth. Do not
+implement a Grok Bot-native mail transport.
+
+Grok Bot may revive the parent when a background Task finishes. That helps
+executor recon. It is not a substitute for listen doorbells.
+
+## Multi-controller mail
+
+SendToAgent / named teammate agents are an extra ping between Grok Bot
+controllers that share one project. Controller-mail remains the work plane
+(`goalflight_messages.py`: leases, journal, `post --to-controller`,
+merge-request / patch).
+
+Five-controller setups still use `post --to-controller` plus the portable
+listen pool. That layout is a project convention (lane claims, one integrator,
+cluster dispatch), not a Goal Flight primitive. A Grok Bot controller joining
+such a project must claim its own label, stamp
+`--controller-label --controller-pid --controller-session-id` on every
+dispatch, and never steal the existing leases. Read
+`docs-private/MULTI-CONTROLLER-ETIQUETTE.md` when the project has one.
+
+## Advanced setup
+
+Dry-run first, omit `--apply --yes`:
+
+```bash
+./setup.sh --grok-bot
+./setup.sh --agent grok-bot --addons ''
+```
+
+After setup, run Goal Flight init in the target project on the Mac checkout.
+Init runs doctor, capacity checks, worker readiness checks, and writes compact
+project-local caveats.

--- a/docs/hosts/grok-bot.md
+++ b/docs/hosts/grok-bot.md
@@ -61,14 +61,18 @@ Load order: `AGENTS.md` → this host wrapper → repository `SKILL.md` →
   doctor. Conversation is not the backlog.
 - Controller label is `goalflight-grokbot`. Stamp it on every dispatch.
 - Dispatch CLI workers on the user's registered computer (the Mac checkout)
-  via Grok Bot Shell with a `machineId`. Do not spawn workers on the Grok Bot
-  box and do not clone the repo onto the box.
+  via Grok Bot Shell with a `machineId`. Do not spawn CLI workers on the
+  Grok Bot box and do not clone the repo onto the box. Task / executor
+  subagents start on the box and must be pinned to that Mac in the prompt
+  (see Executor context package).
 - Wrap the existing CLIs: `goalflight_dispatch.py`, `goalflight_messages.py`,
   `goalflight_task.py`, status, doctor. Do not add a parallel store.
 - Grok Bot Task / executor subagents are a **first-class** host `delegate`
-  surface, distinct from CLI ACP / bash-tail workers. Choose Executor vs CLI
-  from token/budget and task shape. Do **not** apply the Claude-host
-  "Host Agent as code executor = LAST RESORT" rule here.
+  surface, distinct from CLI ACP / bash-tail workers. They start blank;
+  judgment-bearing Task prompts reuse the Claude host-subagent pin (see
+  Executor context package). Choose Executor vs CLI from token/budget and
+  task shape. Do **not** apply the Claude-host "Host Agent as code executor
+  = LAST RESORT" rule here.
 - Code-writing: CLI (`--agent codex`, `--agent grok-code`, `--agent moonshot`)
   when capacity is healthy; Executor when that lane is cheaper/available or
   the chunk is host-native (recon, synthesis, mail, status).
@@ -79,6 +83,41 @@ Load order: `AGENTS.md` → this host wrapper → repository `SKILL.md` →
 - Grok Bot Cloud Agents = optional extra worker for GitHub-branch / PR chunks
   only; never the default for a local scientific-coding project.
 - Do not pin Grok model ids.
+
+## Executor context package
+
+Grok Bot Task / executor subagents start **blank**: no chat, no memory, no
+SKILL.md, and none of the controller conversation. Reuse the existing
+Claude host-subagent pin. Do not invent a parallel package format. Do not
+add a grok-executor template — Cursor and Grok CLI wrappers have none.
+
+CLI workers keep the existing five-layer `--prompt-file` dispatch
+(compose via `prompts/dispatch-wrapper.md`; do not paste that recipe
+file into a Task). Executors get **that same composed prompt-file body**
+in the Task prompt (paste it, or cite its stable Mac path).
+
+Compose every judgment-bearing grok-executor Task prompt in this order:
+
+1. Open with `protocols/subagent-preamble.md` verbatim. Fill only
+   repository path + north star. Repository path is the Mac checkout,
+   e.g. `/Users/simonrowland/Repos/<project>`.
+2. Immediately after the preamble, the grok-bot-only pin: executors
+   default to the Grok Bot computer, **not** the user's Mac. Name
+   `machineId` / "the user's registered computer" and absolute paths
+   under `/Users/simonrowland/Repos/...`. Every Read and Shell —
+   including the preamble's AGENTS.md / ORIENTATION.md reads — uses
+   `machineId`. Do not clone the repo onto the box.
+3. Always pointer to `docs-private/rag/ORIENTATION.md` when present
+   (orientation only).
+4. If the lane is triggered, apply `protocols/worker-context-package.md`
+   in full: verbatim brief prepend (never link-instead-of-paste), quoted
+   ground-truth spec, named guard tests, standing re-read. Then the
+   `--prompt-file` equivalent: the same five-layer body CLI would get.
+   Citing a Mac path is allowed for that composed prompt file; it does
+   not replace the verbatim brief or quoted spec.
+
+Live Codex dispatch on the user's Mac is a host smoke, not part of this
+port's hermetic coverage.
 
 ## Wake path
 

--- a/docs/hosts/grok-bot.md
+++ b/docs/hosts/grok-bot.md
@@ -295,12 +295,24 @@ A token-pause or host update typically shows up as listen **exit 5**
 the next 15-minute listen arm/timeout attempt, should claim and re-arm.
 Do not wait for the human to remember compaction.
 
+The operator is the **former mailman**. Do not ask them to paste messages
+between controllers or to tell another session to check mail. Deafness
+is re-arm listen, not user-as-mailman.
+
 ## Multi-controller mail
 
-SendToAgent / named teammate agents are an extra ping between Grok Bot
-controllers that share one project. Controller-mail remains the work plane
-(`goalflight_messages.py`: leases, journal, `post --to-controller`,
-merge-request / patch).
+Inter-controller traffic is **only**
+`goalflight_messages.py post --to-controller`. Grok-bot controllers join
+that journal. Do not ask the user to paste mail, and do not ask them to
+tell another session to check mail.
+
+SendToAgent (Grok Bot teammate DMs) is an optional extra ping among
+grok-bot agents. It is never the work inbox and never the bridge to
+Claude `battery-*` controllers.
+
+Deafness is re-arm listen, not user-as-mailman. A controller that is not
+seeing mail has an unarmed or dead doorbell (`wake unarmed`); re-arm
+it. Do not route the missing wake through the operator.
 
 Five-controller setups still use `post --to-controller` plus the portable
 listen pool. That layout is a project convention (lane claims, one integrator,

--- a/docs/hosts/grok-bot.md
+++ b/docs/hosts/grok-bot.md
@@ -81,17 +81,62 @@ Load order: `AGENTS.md` → this host wrapper → repository `SKILL.md` →
 
 ## Wake path
 
-`supervise` needs a host monitor where each flushed stdout line is a
-controller notification, unbounded, `persistent: true`. Grok Bot does not
-have Claude Code's persistent stdout monitor.
+How a Grok Bot controller learns a worker finished: use the existing
+journal doorbell (`listen`), not a new event bus and not a Settings widget.
 
-Documented wake path: the portable `goalflight_messages.py listen` doorbell
-(exit-as-wake). On each ring, process mail, then restore listen depth. Do not
-implement a Grok Bot-native mail transport.
+**Journal is durable truth.** Worker terminals are the markers in
+`protocols/worker-markers.md`: `!COMPLETE` / `!READY` / `!FAILED` /
+`!BLOCKED` / `!USER-NEED` (leading `!` optional). There is no `!FINISHED`
+in that protocol; if the word appears, alias it to `!COMPLETE`. The watcher
+already harvests those into the terminal-outbox / controller mail.
 
-Grok Bot may revive the parent when a background Task / Executor finishes.
-That helps host-native Executor work. It is not a substitute for listen
-doorbells.
+**Host monitor is exit-as-wake.** Grok Bot revives the parent chat when a
+Task / executor or a tracked Shell completes. That is the same contract as
+`goalflight_messages.py listen`, not Claude's persistent line-break
+`supervise` / `follow`. There is no separate Settings "monitor widget"; the
+running background task / subagent card is the UI.
+
+**Canonical grok-bot arm** — one tracked `listen --report-pending` on the
+**user's Mac** (the project checkout), with `--project-root` and
+`--controller-label`. Never detach it (`nohup`, `&`, disown): a detached
+listener refuses with **exit 4** and cannot wake an untracked parent.
+
+```bash
+python3 <skill-root>/scripts/goalflight_messages.py listen \
+  --project-root "$PWD" \
+  --controller-label "$GOALFLIGHT_CONTROLLER_LABEL" \
+  --report-pending
+```
+
+On ring (**exit 0**): drain with `relay --drain`, act, re-arm. The portable
+four-listen pool is full depth (resilience; see
+`protocols/controller-mail.md`). One listen is the MVP. Branch on listen
+exit codes instead of blindly restarting:
+
+| Code | Meaning for this host | Action |
+|---:|---|---|
+| 0 | Ring | `relay --drain`, act, re-arm |
+| 1 | Timeout | Re-arm only if coverage is still required |
+| 2 | Journal unreadability | Repair/escalate; do not restart-loop |
+| 3 | Contention / stale lease | Reconcile the live lease; re-arm only under it |
+| 4 | Detached refusal (`nohup` / `&` / disown) | Launch a tracked listener; do not detach again |
+| 5 | Did-not-arm (dead nonce) | Do not re-arm that nonce |
+
+**Do not arm unbounded `supervise` as a Grok Bot background shell** expecting
+per-line wakes. Grok Bot only notifies on job completion. Supervise
+heartbeats (~120s) would either never complete or, if every line were
+awaited, spam turns. If you add a helper, it must wrap `listen` or exit on
+the first actionable event (ignore heartbeat / frontier keepalives).
+
+A same-turn regex-wait on a live `supervise` process (host AwaitShell-style
+blocking) is a same-turn block, not a session-life monitor. Do not recommend
+it as the default.
+
+**Missed wake is latency, not data loss.** Resume still pulls
+`goalflight_status.py`, `goalflight_task.py next`, and `relay --new`.
+
+This port documents the listen doorbell mapping only. Do not implement a Grok
+Bot-native mail transport.
 
 ## Multi-controller mail
 

--- a/docs/hosts/grok-bot.md
+++ b/docs/hosts/grok-bot.md
@@ -86,10 +86,13 @@ resuming.
   only; never the default for a local scientific-coding project.
 - Do not pin Grok model ids.
 - Grok Bot has no `/compact` and no keep-vs-toss prompt. Autocompact +
-  keep handoff current. Do not port the Claude context-meter or
-  SessionStart hooks. Write the `state-handoff.md` Before compact or
-  sleep block on every listen ring/timeout and before long waves, then
-  quote-check Hard Invariants from disk. Do not ask the user to compact.
+  keep handoff current. The operator is not the compaction mailman.
+  Do not port the Claude context-meter or SessionStart hooks. Write the
+  `state-handoff.md` Before compact or sleep block on every listen
+  ring/timeout and before long waves, then quote-check Hard Invariants
+  from disk. Do not ask the user to compact. The one operator
+  wake-hygiene job is re-arming listen doorbells after a host update or
+  token-pause, surfaced as roster `wake unarmed` — see Operator role.
 
 ## Executor context package
 
@@ -265,6 +268,32 @@ If this controller cannot quote `SKILL.md` Hard Invariants from a
 3. store baseline (`goalflight_status.py` + `goalflight_task.py list`)
 4. newest RESUME-NOTES
 5. `goalflight_task.py next`
+
+## Operator role
+
+The operator is **not** the compaction mailman. No `/compact`, no
+keep-vs-toss ask. Autocompact plus the 15-minute doorbell mini-resume
+(flush RESUME-NOTES, quote-check Hard Invariants from disk, task next)
+owns that job. Do not ask the user to manage compactions.
+
+The operator **is** allowed one wake-hygiene job, the same one Claude
+already has: after a host update or token-exhaustion pause, re-arm the
+listen doorbells (Claude re-arms Monitor / `supervise`). Surface that
+via roster fields already measured — `wake_armed`, `wake_covered`,
+`supervisor` absent — the same signal as a battery-engine
+`wake unarmed` note. `goalflight_session_status.py` already prints
+`wake unarmed` / `wake unarmed with N non-terminal dispatches`. Do not
+invent a second reminder channel.
+
+On grok-bot the listen pool is the arm. `supervisor: absent` is expected
+when no `supervise` process is running; that alone is not the alarm.
+The operator-facing alarm is `wake unarmed` (`wake_armed` false, usually
+with `wake_covered` false).
+
+A token-pause or host update typically shows up as listen **exit 5**
+(dead lease nonce) or as reaped tracked tasks. The next user message, or
+the next 15-minute listen arm/timeout attempt, should claim and re-arm.
+Do not wait for the human to remember compaction.
 
 ## Multi-controller mail
 

--- a/docs/hosts/grok-bot.md
+++ b/docs/hosts/grok-bot.md
@@ -53,9 +53,11 @@ Resync from the source repo (or the pinned `~/.goal-flight/skill/`) with
 
 ## How a Grok Bot controller operates
 
-Load order: `AGENTS.md` → this host wrapper → repository `SKILL.md` →
-`protocols/guidance-extended.md` by default (non-frontier) → newest
-`docs-private/RESUME-NOTES-*.md` when resuming.
+Load order: `AGENTS.md` → this host wrapper (Freshness: disk-read
+`SKILL.md` Hard Invariants; if you cannot quote them, resume before
+acting) → repository `SKILL.md` → `protocols/guidance-extended.md` by
+default (non-frontier) → newest `docs-private/RESUME-NOTES-*.md` when
+resuming.
 
 - Facts come from `goalflight_status.py`, `goalflight_task.py list/next`, and
   doctor. Conversation is not the backlog.
@@ -83,9 +85,11 @@ Load order: `AGENTS.md` → this host wrapper → repository `SKILL.md` →
 - Grok Bot Cloud Agents = optional extra worker for GitHub-branch / PR chunks
   only; never the default for a local scientific-coding project.
 - Do not pin Grok model ids.
-- Grok Bot has no `/compact` and no keep-vs-toss prompt. Write the
-  `state-handoff.md` Before compact or sleep block on the 15-minute
-  frontier ping and before long waves. Do not ask the user to compact.
+- Grok Bot has no `/compact` and no keep-vs-toss prompt. Autocompact +
+  keep handoff current. Do not port the Claude context-meter or
+  SessionStart hooks. Write the `state-handoff.md` Before compact or
+  sleep block on every listen ring/timeout and before long waves, then
+  quote-check Hard Invariants from disk. Do not ask the user to compact.
 
 ## Executor context package
 
@@ -147,25 +151,28 @@ it does not stall. That is **not** Claude's follow-stream heartbeat
 not change the global `supervise` / `follow` cadence in this port; 900s
 is a grok-bot wrapper-local default on the listen arm.
 
-**Canonical grok-bot arm** — one tracked `listen --report-pending
---timeout-s 900` on the **user's Mac** (the project checkout), with
-`--project-root` and `--controller-label goalflight-grokbot`. Never
-detach it (`nohup`, `&`, disown): a detached listener refuses with
-**exit 4** and cannot wake an untracked parent.
+**Canonical grok-bot arm** — one tracked
+`goalflight_grok_bot_listen.py --report-pending --timeout-s 900` on the
+**user's Mac** (the project checkout), with `--project-root` and
+`--controller-label goalflight-grokbot`. That helper wraps
+`listen --report-pending` and prints the quote-check banner on every
+exit. Never detach it (`nohup`,
+`&`, disown): a detached listener refuses with **exit 4** and cannot
+wake an untracked parent.
 
 ```bash
-python3 <skill-root>/scripts/goalflight_messages.py listen \
+python3 <skill-root>/scripts/goalflight_grok_bot_listen.py \
   --project-root "$PWD" \
   --controller-label goalflight-grokbot \
   --report-pending \
   --timeout-s 900
 ```
 
-On ring (**exit 0**): drain with `relay --drain`, act, re-arm. On
-timeout (**exit 1**): run the directed-compact write (Compaction
-below), pull `goalflight_status.py` and `goalflight_task.py next`, then
-re-arm — that exit *is* the 15-minute frontier reminder and the last
-reliable moment before an unannounced host summary. The portable
+Every ring (**exit 0**) or timeout (**exit 1**) is a **mini-resume**:
+drain if it rang (`relay --drain`, act), flush RESUME-NOTES (Compaction
+below), quote-check Hard Invariants from a fresh disk read, re-arm,
+then `goalflight_task.py next`. The 900s quiet timeout is this host's
+substitute for Claude's 80% context-meter hint. The portable
 four-listen pool is full depth
 (resilience; see `protocols/controller-mail.md`). One listen is the MVP.
 If you arm more than one listen, put `--timeout-s 900` on a single slot
@@ -175,8 +182,8 @@ restarting:
 
 | Code | Meaning for this host | Action |
 |---:|---|---|
-| 0 | Ring | `relay --drain`, act, re-arm |
-| 1 | 15-minute frontier ping (quiet timeout) | Handoff write + status + task next, re-arm |
+| 0 | Ring | Drain, act, handoff write, quote-check, re-arm, task next |
+| 1 | 15-minute frontier ping (quiet timeout) | Handoff write, quote-check, re-arm, task next |
 | 2 | Journal unreadability | Repair/escalate; do not restart-loop |
 | 3 | Contention / stale lease | Reconcile the live lease; re-arm only under it |
 | 4 | Detached refusal (`nohup` / `&` / disown) | Launch a tracked listener; do not detach again |
@@ -199,6 +206,14 @@ Bot-native mail transport.
 
 ## Compaction
 
+Grok Bot = **autocompact + keep handoff current**. Do **not** port
+`scripts/hooks/goalflight-context-meter.sh` or Claude PostToolUse
+`additionalContext` 80/90/95% bands. That hook is Claude-Code-specific.
+Grok Bot has no PostToolUse `additionalContext` injection and no
+trustworthy window %. A fake meter is worse than none. Claude
+context-meter and SessionStart watchdog stay Claude-only. There is no
+SessionStart hook on grok-bot.
+
 Claude's directed compact is a controller-authored keep-vs-toss prompt,
 then `/compact`, then `/goal-flight resume`. Grok Bot has **no**
 controller-authored `/compact` and **no** keep-vs-toss prompt. The host
@@ -215,8 +230,25 @@ The directed-compact step on this host **is**
   deferred / held when relevant)
 - `goalflight_status.py`
 
-Write that on the 15-minute frontier heartbeat (listen exit 1) and
-before long waves. There is no warning before the host summarizes.
+The 15-minute listen timeout is the substitute for Claude's 80% hint.
+On **every** ring or timeout, flush that handoff, then quote-check. Also
+write before long waves. There is no warning before the host summarizes.
+
+The Hard Invariants quoting rule cannot live only in compacted SKILL.md.
+Externalize it:
+
+1. Wrapper Freshness preamble (always loaded): disk-read SKILL.md Hard
+   Invariants; if you cannot quote them, stale → resume before acting.
+2. Listen/heartbeat stdout banner (doorbell is outside the chat):
+   `goalflight_grok_bot_listen.py` prints
+   `QUOTE-CHECK: disk-read SKILL.md Hard Invariants; if you cannot quote them, stale — resume before acting.`
+   on every listen exit.
+3. Optional operator-side Grok Bot profile sentence:
+   `On every Goal Flight listen exit, disk-read SKILL.md Hard Invariants; if you cannot quote them, resume before acting.`
+
+Every 15-minute wake is a mini-resume: drain if it rang, flush
+RESUME-NOTES, quote-check from disk, re-arm doorbells,
+`goalflight_task.py next`.
 
 Resume reload and rebuild are unchanged. Chat summaries are hints, not
 substitutes. Grok Bot profile, `update_state` memory, and routines may

--- a/docs/hosts/grok-bot.md
+++ b/docs/hosts/grok-bot.md
@@ -64,12 +64,20 @@ Load order: `AGENTS.md` → this host wrapper → repository `SKILL.md` →
   box and do not clone the repo onto the box.
 - Wrap the existing CLIs: `goalflight_dispatch.py`, `goalflight_messages.py`,
   `goalflight_task.py`, status, doctor. Do not add a parallel store.
-- Grok Bot Task / executor subagents = recon / analysis / review only.
+- Grok Bot Task / executor subagents are a **first-class** host `delegate`
+  surface, distinct from CLI ACP / bash-tail workers. Choose Executor vs CLI
+  from token/budget and task shape. Do **not** apply the Claude-host
+  "Host Agent as code executor = LAST RESORT" rule here.
+- Code-writing: CLI (`--agent codex`, `--agent grok-code`, `--agent moonshot`)
+  when capacity is healthy; Executor when that lane is cheaper/available or
+  the chunk is host-native (recon, synthesis, mail, status).
+- Reviews: kimi3 or codex as independent reviewers. kimi3 is
+  `--agent moonshot` (`adapters/moonshot.json`, default model `kimi-code/k3`).
+  Do not invent a `kimi3` agent id. `forbid_self_review` still applies: a
+  Grok Bot controller must not Type-1-review a `grok-code` worker.
 - Grok Bot Cloud Agents = optional extra worker for GitHub-branch / PR chunks
   only; never the default for a local scientific-coding project.
-- Same-provider review is `forbid_self_review`. A Grok Bot controller must not
-  Type-1-review a `grok-code` worker. Independent engine (codex / gstack)
-  remains the default. Do not pin Grok model ids.
+- Do not pin Grok model ids.
 
 ## Wake path
 
@@ -81,8 +89,9 @@ Documented wake path: the portable `goalflight_messages.py listen` doorbell
 (exit-as-wake). On each ring, process mail, then restore listen depth. Do not
 implement a Grok Bot-native mail transport.
 
-Grok Bot may revive the parent when a background Task finishes. That helps
-executor recon. It is not a substitute for listen doorbells.
+Grok Bot may revive the parent when a background Task / Executor finishes.
+That helps host-native Executor work. It is not a substitute for listen
+doorbells.
 
 ## Multi-controller mail
 

--- a/docs/hosts/grok-bot.md
+++ b/docs/hosts/grok-bot.md
@@ -59,6 +59,7 @@ Load order: `AGENTS.md` → this host wrapper → repository `SKILL.md` →
 
 - Facts come from `goalflight_status.py`, `goalflight_task.py list/next`, and
   doctor. Conversation is not the backlog.
+- Controller label is `goalflight-grokbot`. Stamp it on every dispatch.
 - Dispatch CLI workers on the user's registered computer (the Mac checkout)
   via Grok Bot Shell with a `machineId`. Do not spawn workers on the Grok Bot
   box and do not clone the repo onto the box.
@@ -86,9 +87,9 @@ journal doorbell (`listen`), not a new event bus and not a Settings widget.
 
 **Journal is durable truth.** Worker terminals are the markers in
 `protocols/worker-markers.md`: `!COMPLETE` / `!READY` / `!FAILED` /
-`!BLOCKED` / `!USER-NEED` (leading `!` optional). There is no `!FINISHED`
-in that protocol; if the word appears, alias it to `!COMPLETE`. The watcher
-already harvests those into the terminal-outbox / controller mail.
+`!BLOCKED` / `!USER-NEED` (leading `!` optional). `!COMPLETE` is the
+success terminal. The watcher already harvests those into the
+terminal-outbox / controller mail.
 
 **Host monitor is exit-as-wake.** Grok Bot revives the parent chat when a
 Task / executor or a tracked Shell completes. That is the same contract as
@@ -96,37 +97,51 @@ Task / executor or a tracked Shell completes. That is the same contract as
 `supervise` / `follow`. There is no separate Settings "monitor widget"; the
 running background task / subagent card is the UI.
 
-**Canonical grok-bot arm** — one tracked `listen --report-pending` on the
-**user's Mac** (the project checkout), with `--project-root` and
-`--controller-label`. Never detach it (`nohup`, `&`, disown): a detached
-listener refuses with **exit 4** and cannot wake an untracked parent.
+**Portable listen / heartbeat pool.** Use the existing listen doorbells.
+This host's frontier ping is `listen --timeout-s 900` (15 minutes of
+quiet): the timeout exit reminds the controller of the task frontier so
+it does not stall. That is **not** Claude's follow-stream heartbeat
+(120s; the stream range is 60–300s and would spam Grok Bot turns). Do
+not change the global `supervise` / `follow` cadence in this port; 900s
+is a grok-bot wrapper-local default on the listen arm.
+
+**Canonical grok-bot arm** — one tracked `listen --report-pending
+--timeout-s 900` on the **user's Mac** (the project checkout), with
+`--project-root` and `--controller-label goalflight-grokbot`. Never
+detach it (`nohup`, `&`, disown): a detached listener refuses with
+**exit 4** and cannot wake an untracked parent.
 
 ```bash
 python3 <skill-root>/scripts/goalflight_messages.py listen \
   --project-root "$PWD" \
-  --controller-label "$GOALFLIGHT_CONTROLLER_LABEL" \
-  --report-pending
+  --controller-label goalflight-grokbot \
+  --report-pending \
+  --timeout-s 900
 ```
 
-On ring (**exit 0**): drain with `relay --drain`, act, re-arm. The portable
-four-listen pool is full depth (resilience; see
-`protocols/controller-mail.md`). One listen is the MVP. Branch on listen
-exit codes instead of blindly restarting:
+On ring (**exit 0**): drain with `relay --drain`, act, re-arm. On
+timeout (**exit 1**): pull `goalflight_status.py` and
+`goalflight_task.py next`, then re-arm — that exit *is* the 15-minute
+frontier reminder. The portable four-listen pool is full depth
+(resilience; see `protocols/controller-mail.md`). One listen is the MVP.
+If you arm more than one listen, put `--timeout-s 900` on a single slot
+and leave the others at `--timeout-s 0` so four quiet timeouts do not
+fire together. Branch on listen exit codes instead of blindly
+restarting:
 
 | Code | Meaning for this host | Action |
 |---:|---|---|
 | 0 | Ring | `relay --drain`, act, re-arm |
-| 1 | Timeout | Re-arm only if coverage is still required |
+| 1 | 15-minute frontier ping (quiet timeout) | Pull status + task next, re-arm |
 | 2 | Journal unreadability | Repair/escalate; do not restart-loop |
 | 3 | Contention / stale lease | Reconcile the live lease; re-arm only under it |
 | 4 | Detached refusal (`nohup` / `&` / disown) | Launch a tracked listener; do not detach again |
 | 5 | Did-not-arm (dead nonce) | Do not re-arm that nonce |
 
 **Do not arm unbounded `supervise` as a Grok Bot background shell** expecting
-per-line wakes. Grok Bot only notifies on job completion. Supervise
-heartbeats (~120s) would either never complete or, if every line were
-awaited, spam turns. If you add a helper, it must wrap `listen` or exit on
-the first actionable event (ignore heartbeat / frontier keepalives).
+per-line wakes. Grok Bot only notifies on job completion. If you add a
+helper, it must wrap `listen` or exit on the first actionable event
+(ignore stream heartbeat / frontier keepalives).
 
 A same-turn regex-wait on a live `supervise` process (host AwaitShell-style
 blocking) is a same-turn block, not a session-life monitor. Do not recommend
@@ -148,9 +163,10 @@ merge-request / patch).
 Five-controller setups still use `post --to-controller` plus the portable
 listen pool. That layout is a project convention (lane claims, one integrator,
 cluster dispatch), not a Goal Flight primitive. A Grok Bot controller joining
-such a project must claim its own label, stamp
-`--controller-label --controller-pid --controller-session-id` on every
-dispatch, and never steal the existing leases. Read
+such a project must claim `goalflight-grokbot` (or another unused label)
+and stamp that claimed label with `--controller-pid
+--controller-session-id` on every dispatch, and never steal the existing
+leases. Read
 `docs-private/MULTI-CONTROLLER-ETIQUETTE.md` when the project has one.
 
 ## Advanced setup

--- a/docs/hosts/grok-bot.md
+++ b/docs/hosts/grok-bot.md
@@ -18,6 +18,7 @@ One-shot install (wrapper copy into the Grok Bot workflows library):
 # when the workflows library root is not the bot-box default:
 ./install.sh grok-bot /home/box/agent-data/workflows
 # or: GOALFLIGHT_GROK_BOT_WORKFLOWS=/path/to/workflows ./install.sh grok-bot
+# Bare install also applies default gstack/autoreview addons; --addons '' skips.
 ```
 
 ## Install destination (verified, with uncertainty)
@@ -38,8 +39,12 @@ cannot see `/home/box/...` must pass the override; this repo does not invent a
 second default Mac path.
 
 Doctor's `installed_skill_drift` hashes the installed wrapper against
-`configs/grok-bot/skills/goal-flight/SKILL.md`. A WARN means resync with
-`./install.sh grok-bot`.
+`configs/grok-bot/skills/goal-flight/SKILL.md`. That installed path is
+the box library (or `GOALFLIGHT_GROK_BOT_WORKFLOWS`). A Mac
+`--project-root` doctor without the override will not see
+`/home/box/...`; run the drift check on the box, or set the override.
+A WARN means resync with `./install.sh grok-bot`. Do not invent a
+second Mac default library root.
 
 ## Resync after SKILL.md changes
 
@@ -318,9 +323,9 @@ Five-controller setups still use `post --to-controller` plus the portable
 listen pool. That layout is a project convention (lane claims, one integrator,
 cluster dispatch), not a Goal Flight primitive. A Grok Bot controller joining
 such a project must claim `goalflight-grokbot` (or another unused label)
-and stamp that claimed label with `--controller-pid
---controller-session-id` on every dispatch, and never steal the existing
-leases. Read
+and stamp that claimed label with `--controller-pid <pid>
+--controller-session-id <session-id>` on every dispatch, and never steal
+the existing leases. Read
 `docs-private/MULTI-CONTROLLER-ETIQUETTE.md` when the project has one.
 
 ## Advanced setup

--- a/docs/hosts/grok-bot.md
+++ b/docs/hosts/grok-bot.md
@@ -83,6 +83,9 @@ Load order: `AGENTS.md` → this host wrapper → repository `SKILL.md` →
 - Grok Bot Cloud Agents = optional extra worker for GitHub-branch / PR chunks
   only; never the default for a local scientific-coding project.
 - Do not pin Grok model ids.
+- Grok Bot has no `/compact` and no keep-vs-toss prompt. Write the
+  `state-handoff.md` Before compact or sleep block on the 15-minute
+  frontier ping and before long waves. Do not ask the user to compact.
 
 ## Executor context package
 
@@ -159,9 +162,11 @@ python3 <skill-root>/scripts/goalflight_messages.py listen \
 ```
 
 On ring (**exit 0**): drain with `relay --drain`, act, re-arm. On
-timeout (**exit 1**): pull `goalflight_status.py` and
-`goalflight_task.py next`, then re-arm — that exit *is* the 15-minute
-frontier reminder. The portable four-listen pool is full depth
+timeout (**exit 1**): run the directed-compact write (Compaction
+below), pull `goalflight_status.py` and `goalflight_task.py next`, then
+re-arm — that exit *is* the 15-minute frontier reminder and the last
+reliable moment before an unannounced host summary. The portable
+four-listen pool is full depth
 (resilience; see `protocols/controller-mail.md`). One listen is the MVP.
 If you arm more than one listen, put `--timeout-s 900` on a single slot
 and leave the others at `--timeout-s 0` so four quiet timeouts do not
@@ -171,7 +176,7 @@ restarting:
 | Code | Meaning for this host | Action |
 |---:|---|---|
 | 0 | Ring | `relay --drain`, act, re-arm |
-| 1 | 15-minute frontier ping (quiet timeout) | Pull status + task next, re-arm |
+| 1 | 15-minute frontier ping (quiet timeout) | Handoff write + status + task next, re-arm |
 | 2 | Journal unreadability | Repair/escalate; do not restart-loop |
 | 3 | Contention / stale lease | Reconcile the live lease; re-arm only under it |
 | 4 | Detached refusal (`nohup` / `&` / disown) | Launch a tracked listener; do not detach again |
@@ -191,6 +196,43 @@ it as the default.
 
 This port documents the listen doorbell mapping only. Do not implement a Grok
 Bot-native mail transport.
+
+## Compaction
+
+Claude's directed compact is a controller-authored keep-vs-toss prompt,
+then `/compact`, then `/goal-flight resume`. Grok Bot has **no**
+controller-authored `/compact` and **no** keep-vs-toss prompt. The host
+may summarize the chat on its own. Do not invent a compact UI.
+Do not ask the user to compact. Do not emulate Claude's compact prompt in chat.
+
+The directed-compact step on this host **is**
+`protocols/state-handoff.md` "Before compact or sleep":
+
+- update newest `docs-private/RESUME-NOTES-<YYYY-MM-DD>.md` with
+  ENVIRONMENT / IDEAS / DECISIONS / FACTS / CARRIERS only — no task tables,
+  dispatch codes, or next-task lists
+- store baseline via `goalflight_task.py list` (outstanding, plus
+  deferred / held when relevant)
+- `goalflight_status.py`
+
+Write that on the 15-minute frontier heartbeat (listen exit 1) and
+before long waves. There is no warning before the host summarizes.
+
+Resume reload and rebuild are unchanged. Chat summaries are hints, not
+substitutes. Grok Bot profile, `update_state` memory, and routines may
+persist across summaries; they are advisory. Repository files remain
+the canonical memory backend.
+
+If this controller cannot quote `SKILL.md` Hard Invariants from a
+**fresh disk read**, reload `AGENTS.md` → grok-bot wrapper → repository
+`SKILL.md` → `commands/resume.md`. Then:
+
+1. `goalflight_session_status.py --text`
+2. **Skip** `commands/resume.md` STEP 1.5 (`supervise`). Arm listen
+   doorbells (portable pool) instead.
+3. store baseline (`goalflight_status.py` + `goalflight_task.py list`)
+4. newest RESUME-NOTES
+5. `goalflight_task.py next`
 
 ## Multi-controller mail
 

--- a/install.sh
+++ b/install.sh
@@ -52,6 +52,9 @@ detect_host_from_args() {
     codex)
       DETECTED_HOST=codex
       ;;
+    grok-bot)
+      DETECTED_HOST=grok-bot
+      ;;
     claude-acp)
       DETECTED_HOST=claude
       ;;
@@ -63,12 +66,20 @@ detect_host_from_args() {
             DETECTED_HOST=codex
             return 0
             ;;
+          --grok-bot|--grok-bot-install)
+            DETECTED_HOST=grok-bot
+            return 0
+            ;;
           --agent=codex)
             DETECTED_HOST=codex
             return 0
             ;;
           --agent=claude)
             DETECTED_HOST=claude
+            return 0
+            ;;
+          --agent=grok-bot)
+            DETECTED_HOST=grok-bot
             return 0
             ;;
         esac
@@ -78,6 +89,10 @@ detect_host_from_args() {
         fi
         if [[ "$prev" == --agent && "$arg" == claude ]]; then
           DETECTED_HOST=claude
+          return 0
+        fi
+        if [[ "$prev" == --agent && "$arg" == grok-bot ]]; then
+          DETECTED_HOST=grok-bot
           return 0
         fi
         prev="$arg"
@@ -195,6 +210,15 @@ if [[ $# -ge 1 ]]; then
     grok)
       shift
       bash "${REPO_ROOT}/scripts/hosts/fleet/install_grok.sh" "$@"
+      exit $?
+      ;;
+    grok-bot)
+      shift
+      if [[ $# -ge 1 && "$1" != -* ]]; then
+        run_setup_and_traits --grok-bot-install "$1" "${@:2}"
+      else
+        run_setup_and_traits --grok-bot-install "$@"
+      fi
       exit $?
       ;;
     claude-acp)

--- a/scripts/goalflight_doctor.py
+++ b/scripts/goalflight_doctor.py
@@ -1493,6 +1493,13 @@ def _sha256_file(path: Path) -> str:
     return digest.hexdigest()
 
 
+def _grok_bot_workflows_root() -> Path:
+    raw = os.environ.get("GOALFLIGHT_GROK_BOT_WORKFLOWS", "").strip()
+    if raw:
+        return Path(raw).expanduser()
+    return Path("/home/box/agent-data/workflows")
+
+
 def check_host_goalflight_install() -> dict:
     home = Path.home()
     codex_plugin_cache = sorted(
@@ -1508,6 +1515,7 @@ def check_host_goalflight_install() -> dict:
     opencode_config = home / ".config/opencode/opencode.json"
     standard_agents_skill = home / ".agents/skills/goal-flight/SKILL.md"
     grok_skill = home / ".grok/skills/goal-flight/SKILL.md"
+    grok_bot_skill = _grok_bot_workflows_root() / "goal-flight/SKILL.md"
     claude_skill = home / ".claude/skills/goal-flight/SKILL.md"
     payload = {
         "codex": {
@@ -1532,6 +1540,10 @@ def check_host_goalflight_install() -> dict:
         "grok": {
             "ok": grok_skill.exists(),
             "skill": _path_state(grok_skill),
+        },
+        "grok-bot": {
+            "ok": grok_bot_skill.exists(),
+            "skill": _path_state(grok_bot_skill),
         },
         "claude": {
             "ok": claude_skill.exists(),
@@ -1618,6 +1630,7 @@ def check_installed_skill_drift(skill_root: Path, project_root: Path) -> dict:
     cursor_source = skill_root / "configs/cursor/skills/goal-flight/SKILL.md"
     opencode_source = skill_root / "configs/opencode/skills/goal-flight/SKILL.md"
     grok_source = skill_root / "configs/grok/skills/goal-flight/SKILL.md"
+    grok_bot_source = skill_root / "configs/grok-bot/skills/goal-flight/SKILL.md"
     candidates: list[dict] = [
         {
             "host": "codex",
@@ -1666,6 +1679,12 @@ def check_installed_skill_drift(skill_root: Path, project_root: Path) -> dict:
                 "./setup.sh --apply --yes --agent grok && "
                 "./install.sh grok <project>"
             ),
+        },
+        {
+            "host": "grok-bot",
+            "sources": [grok_bot_source],
+            "installed": _grok_bot_workflows_root() / "goal-flight/SKILL.md",
+            "resync_command": "./install.sh grok-bot",
         },
         {
             "host": "claude-code",

--- a/scripts/goalflight_grok_bot_listen.py
+++ b/scripts/goalflight_grok_bot_listen.py
@@ -5,6 +5,11 @@ Claude Code PostToolUse context-meter / SessionStart hooks are not this
 path. Do not port them. Grok Bot has no trustworthy window %; a fake
 meter is worse than none. The doorbell process is outside the chat, so
 this one-liner survives host autocompact.
+
+Host-local defaults (honor explicit overrides; do not change global
+listen defaults): ``--timeout-s 900``, ``--report-pending``, and
+``--controller-label goalflight-grokbot``. A bare helper must not listen
+on an unlabeled inbox.
 """
 
 from __future__ import annotations
@@ -17,13 +22,34 @@ QUOTE_CHECK_BANNER = (
     "QUOTE-CHECK: disk-read SKILL.md Hard Invariants; "
     "if you cannot quote them, stale — resume before acting."
 )
+DEFAULT_CONTROLLER_LABEL = "goalflight-grokbot"
+DEFAULT_TIMEOUT_S = "900"
+
+
+def _has_option(argv: list[str], name: str) -> bool:
+    prefix = f"{name}="
+    return any(arg == name or arg.startswith(prefix) for arg in argv)
+
+
+def _with_host_defaults(argv: list[str]) -> list[str]:
+    """Inject grok-bot listen defaults. Explicit flags win."""
+    out = list(argv)
+    if not _has_option(out, "--timeout-s"):
+        out.extend(["--timeout-s", DEFAULT_TIMEOUT_S])
+    if not _has_option(out, "--controller-label"):
+        out.extend(["--controller-label", DEFAULT_CONTROLLER_LABEL])
+    if not (
+        "--report-pending" in out
+        or "--no-report-pending" in out
+        or any(arg.startswith("--report-pending=") for arg in out)
+    ):
+        out.append("--report-pending")
+    return out
 
 
 def _with_host_timeout(argv: list[str]) -> list[str]:
-    """Host-local default is 900s. Do not change global listen default 0."""
-    if any(arg == "--timeout-s" or arg.startswith("--timeout-s=") for arg in argv):
-        return argv
-    return [*argv, "--timeout-s", "900"]
+    """Back-compat alias; defaults now include label and report-pending."""
+    return _with_host_defaults(argv)
 
 
 def main(argv: list[str]) -> int:
@@ -32,7 +58,7 @@ def main(argv: list[str]) -> int:
         sys.executable,
         str(root / "goalflight_messages.py"),
         "listen",
-        *_with_host_timeout(argv),
+        *_with_host_defaults(argv),
     ]
     proc = subprocess.run(listen, check=False)
     print(QUOTE_CHECK_BANNER, flush=True)

--- a/scripts/goalflight_grok_bot_listen.py
+++ b/scripts/goalflight_grok_bot_listen.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Grok Bot listen wrapper: quote-check banner on every listen exit.
+
+Claude Code PostToolUse context-meter / SessionStart hooks are not this
+path. Do not port them. Grok Bot has no trustworthy window %; a fake
+meter is worse than none. The doorbell process is outside the chat, so
+this one-liner survives host autocompact.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+QUOTE_CHECK_BANNER = (
+    "QUOTE-CHECK: disk-read SKILL.md Hard Invariants; "
+    "if you cannot quote them, stale — resume before acting."
+)
+
+
+def _with_host_timeout(argv: list[str]) -> list[str]:
+    """Host-local default is 900s. Do not change global listen default 0."""
+    if any(arg == "--timeout-s" or arg.startswith("--timeout-s=") for arg in argv):
+        return argv
+    return [*argv, "--timeout-s", "900"]
+
+
+def main(argv: list[str]) -> int:
+    root = Path(__file__).resolve().parent
+    listen = [
+        sys.executable,
+        str(root / "goalflight_messages.py"),
+        "listen",
+        *_with_host_timeout(argv),
+    ]
+    proc = subprocess.run(listen, check=False)
+    print(QUOTE_CHECK_BANNER, flush=True)
+    return int(proc.returncode)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/goalflight_setup.py
+++ b/scripts/goalflight_setup.py
@@ -114,6 +114,27 @@ def _grok_bot_workflows_root() -> Path:
     return Path(GROK_BOT_WORKFLOWS_DEFAULT)
 
 
+def _grok_bot_mac_default_warn(
+    *,
+    platform: str | None = None,
+    env: dict[str, str] | None = None,
+) -> str | None:
+    """Warn when Darwin would write the box default /home/box/... path."""
+    plat = sys.platform if platform is None else platform
+    environ = os.environ if env is None else env
+    if plat != "darwin":
+        return None
+    if str(environ.get("GOALFLIGHT_GROK_BOT_WORKFLOWS") or "").strip():
+        return None
+    return (
+        "WARN grok-bot default workflows root is "
+        f"{GROK_BOT_WORKFLOWS_DEFAULT} (Grok Bot box). "
+        "From a Mac checkout pass GOALFLIGHT_GROK_BOT_WORKFLOWS or "
+        "./install.sh grok-bot <workflows-root>. "
+        "This repo does not invent a second Mac default library root."
+    )
+
+
 def _expand_target(raw: str, target_project: Path | None = None) -> Path:
     if TARGET_PROJECT_TOKEN in raw:
         if target_project is None:
@@ -2687,6 +2708,10 @@ def _dry_run(
     *,
     target_project: Path,
 ) -> None:
+    if agent == "grok-bot":
+        warn = _grok_bot_mac_default_warn()
+        if warn:
+            print(warn, file=sys.stderr)
     print(f"DRY-RUN setup agent={agent}")
     if destination_ids:
         print(f"DESTINATIONS selected={','.join(sorted(destination_ids))}")
@@ -2740,6 +2765,10 @@ def _apply(
     target_project: Path,
     gate_checked: bool = False,
 ) -> None:
+    if agent == "grok-bot":
+        warn = _grok_bot_mac_default_warn()
+        if warn:
+            print(warn, file=sys.stderr)
     if not yes:
         raise SetupError("refusing mutation without --yes")
     if not gate_checked:

--- a/scripts/goalflight_setup.py
+++ b/scripts/goalflight_setup.py
@@ -44,6 +44,8 @@ MERGE_START = "# >>> goal-flight"
 MERGE_END = "# <<< goal-flight"
 SETUP_ALLOWED_GATE_REASONS = {"allowed", "candidate", "config_only", "not_installed", "probe_required", "unsupported"}
 TARGET_PROJECT_TOKEN = "${GOALFLIGHT_TARGET_PROJECT}"
+GROK_BOT_WORKFLOWS_TOKEN = "${GOALFLIGHT_GROK_BOT_WORKFLOWS}"
+GROK_BOT_WORKFLOWS_DEFAULT = "/home/box/agent-data/workflows"
 GSTACK_MINIMAL_SKILLS = ("review", "plan-eng-review", "office-hours")
 GSTACK_EXTERNAL_SKILL_SOURCES = {
     "grill-me": (
@@ -105,11 +107,20 @@ def _now_slug() -> str:
     return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
 
 
+def _grok_bot_workflows_root() -> Path:
+    raw = os.environ.get("GOALFLIGHT_GROK_BOT_WORKFLOWS", "").strip()
+    if raw:
+        return Path(raw).expanduser()
+    return Path(GROK_BOT_WORKFLOWS_DEFAULT)
+
+
 def _expand_target(raw: str, target_project: Path | None = None) -> Path:
     if TARGET_PROJECT_TOKEN in raw:
         if target_project is None:
             raise SetupError(f"target path requires --target-project: {raw}")
         raw = raw.replace(TARGET_PROJECT_TOKEN, str(target_project))
+    if GROK_BOT_WORKFLOWS_TOKEN in raw:
+        raw = raw.replace(GROK_BOT_WORKFLOWS_TOKEN, str(_grok_bot_workflows_root()))
     return Path(os.path.expandvars(os.path.expanduser(raw)))
 
 
@@ -2769,7 +2780,7 @@ def _apply(
 
 
 def _expand_host_install_shortcuts(args: argparse.Namespace) -> None:
-    """Map one-shot install flags onto the existing cursor/opencode/codex setup paths."""
+    """Map one-shot install flags onto the existing host setup paths."""
     cursor_install = getattr(args, "cursor_install", None)
     if cursor_install is not None:
         args.apply = True
@@ -2786,6 +2797,13 @@ def _expand_host_install_shortcuts(args: argparse.Namespace) -> None:
         args.apply = True
         args.yes = True
         args.agent = args.agent or "codex"
+    grok_bot_install = getattr(args, "grok_bot_install", None)
+    if grok_bot_install is not None:
+        args.apply = True
+        args.yes = True
+        args.grok_bot = True
+        if grok_bot_install:
+            os.environ["GOALFLIGHT_GROK_BOT_WORKFLOWS"] = grok_bot_install
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -2809,6 +2827,22 @@ def main(argv: list[str] | None = None) -> int:
         "--codex-install",
         action="store_true",
         help="one-shot Codex plugin + CLI worker install; implies --apply --yes --agent codex",
+    )
+    parser.add_argument(
+        "--grok-bot-install",
+        nargs="?",
+        const="",
+        metavar="WORKFLOWS_ROOT",
+        help=(
+            "one-shot Grok Bot controller wrapper install; implies --apply --yes. "
+            "Optional WORKFLOWS_ROOT overrides GOALFLIGHT_GROK_BOT_WORKFLOWS "
+            f"(default {GROK_BOT_WORKFLOWS_DEFAULT})"
+        ),
+    )
+    parser.add_argument(
+        "--grok-bot",
+        action="store_true",
+        help="shortcut for the Grok Bot workflows-library controller setup",
     )
     parser.add_argument("--cursor", action="store_true", help="shortcut for the default Cursor controller/worker setup")
     parser.add_argument(
@@ -2931,6 +2965,8 @@ def main(argv: list[str] | None = None) -> int:
             or getattr(args, "cursor_install", None) is not None
             or getattr(args, "opencode_install", None) is not None
             or getattr(args, "codex_install", False)
+            or args.grok_bot
+            or getattr(args, "grok_bot_install", None) is not None
         )
         if args.tui or (
             not args.agent
@@ -2992,6 +3028,20 @@ def main(argv: list[str] | None = None) -> int:
                 destinations.add("opencode-claude-link-controller")
             if not destinations:
                 destinations.update(_agent_default_destinations(repo_root, "opencode"))
+            addons = _parse_optional_csv(args.addons)
+            _validate_requested_addons(manifests, addons)
+            _run_selection(
+                repo_root,
+                manifests,
+                destinations,
+                addons,
+                apply=args.apply,
+                yes=args.yes,
+                target_project=target_project,
+            )
+            return 0
+        if args.grok_bot:
+            destinations = {"grok-bot-workflows-controller"}
             addons = _parse_optional_csv(args.addons)
             _validate_requested_addons(manifests, addons)
             _run_selection(

--- a/scripts/goalflight_validate_adapters.py
+++ b/scripts/goalflight_validate_adapters.py
@@ -26,6 +26,7 @@ EXPECTED_ADAPTERS = {
     "codex",
     "cursor",
     "grok",
+    "grok-bot",
     "moonshot",
     "gemini",
     "qwen",

--- a/tests/bash/test-agent-adapters.sh
+++ b/tests/bash/test-agent-adapters.sh
@@ -19,7 +19,7 @@ rm -f /tmp/goal-flight-adapters-$$.out /tmp/goal-flight-adapters-$$.err
 
 python3 "$REPO_ROOT/scripts/goalflight_validate_adapters.py" --verbose \
   >/tmp/goal-flight-adapters-$$.out
-grep -q "schema_validates=17/17" /tmp/goal-flight-adapters-$$.out || {
+grep -q "schema_validates=18/18" /tmp/goal-flight-adapters-$$.out || {
   cat /tmp/goal-flight-adapters-$$.out
   rm -f /tmp/goal-flight-adapters-$$.out
   exit 1
@@ -231,6 +231,7 @@ expect_denied_contract(
 )
 
 expect_denied("unsupported", load("amp"), "unsupported", role="controller")
+expect_denied("grok-bot-worker-unsupported", load("grok-bot"), "unsupported", role="worker")
 expect_denied(
     "candidate",
     load("amp"),

--- a/tests/bash/test-goalflight-setup.sh
+++ b/tests/bash/test-goalflight-setup.sh
@@ -21,6 +21,7 @@ run_setup() {
 
 list_out="$(run_setup --list-agents)"
 printf '%s\n' "$list_out" | grep -q 'controller codex-desktop-controller' || fail "codex desktop controller not listed"
+printf '%s\n' "$list_out" | grep -q 'controller grok-bot-workflows-controller' || fail "grok-bot controller not listed"
 printf '%s\n' "$list_out" | grep -q 'worker codex-cli-worker' || fail "codex cli worker not listed"
 printf '%s\n' "$list_out" | grep -q 'addon context-mode' || fail "context-mode add-on not listed"
 printf '%s\n' "$list_out" | grep -q 'addon gstack' || fail "gstack add-on not listed"
@@ -31,7 +32,7 @@ import pathlib
 import sys
 
 root = pathlib.Path(sys.argv[1])
-adapters = ["claude-code", "codex", "cursor", "grok", "opencode"]
+adapters = ["claude-code", "codex", "cursor", "grok", "grok-bot", "opencode"]
 missing = []
 for name in adapters:
     manifest = json.loads((root / "adapters" / f"{name}.json").read_text())
@@ -487,5 +488,27 @@ if python3 "$REPO_ROOT/scripts/goalflight_setup.py" --repo-root "$FIXTURE_REPO" 
   fail "ungated write action should fail"
 fi
 grep -q 'refusing ungated write action' /tmp/goal-flight-setup-ungated.out || fail "ungated write refusal missing"
+
+GROK_BOT_WORKFLOWS="$TMP_ROOT/grok-bot-workflows"
+mkdir -p "$GROK_BOT_WORKFLOWS"
+grok_bot_dry="$(GOALFLIGHT_GROK_BOT_WORKFLOWS="$GROK_BOT_WORKFLOWS" run_setup --grok-bot --addons '')"
+printf '%s\n' "$grok_bot_dry" | grep -q 'DRY-RUN setup agent=grok-bot' || fail "grok-bot dry-run header missing"
+printf '%s\n' "$grok_bot_dry" | grep -q 'DESTINATIONS selected=grok-bot-workflows-controller' || fail "grok-bot shortcut should select workflows controller"
+printf '%s\n' "$grok_bot_dry" | grep -q 'CONTROLLER_SURFACE grok-bot desktop' || fail "grok-bot controller surface missing"
+printf '%s\n' "$grok_bot_dry" | grep -q "configs/grok-bot/skills/goal-flight/SKILL.md" || fail "grok-bot wrapper source missing"
+printf '%s\n' "$grok_bot_dry" | grep -q "$GROK_BOT_WORKFLOWS/goal-flight/SKILL.md" || fail "grok-bot workflows target missing"
+printf '%s\n' "$grok_bot_dry" | grep -q 'PLUGIN skip supported=false' || fail "grok-bot plugin must stay skipped"
+if printf '%s\n' "$grok_bot_dry" | grep -q 'WORKER_CHECK'; then
+  fail "grok-bot controller-only setup should not plan a worker check"
+fi
+[ ! -e "$GROK_BOT_WORKFLOWS/goal-flight/SKILL.md" ] || fail "dry-run mutated grok-bot workflows skill"
+install_grok_bot_alias_dry="$(bash "$REPO_ROOT/install.sh" --grok-bot --addons '')"
+printf '%s\n' "$install_grok_bot_alias_dry" | grep -q 'DRY-RUN setup agent=grok-bot' || fail "install.sh --grok-bot alias did not select grok-bot setup"
+grok_bot_apply="$(GOALFLIGHT_GROK_BOT_WORKFLOWS="$GROK_BOT_WORKFLOWS" run_setup --apply --yes --grok-bot --addons '')"
+grok_bot_manifest="$(printf '%s\n' "$grok_bot_apply" | awk '/^BACKUP_MANIFEST /{print $2}')"
+[ -f "$GROK_BOT_WORKFLOWS/goal-flight/SKILL.md" ] || fail "grok-bot skill not installed"
+grep -q 'Grok Bot' "$GROK_BOT_WORKFLOWS/goal-flight/SKILL.md" || fail "grok-bot skill content missing"
+run_setup --uninstall --from-manifest "$grok_bot_manifest" >/tmp/goal-flight-setup-grok-bot-uninstall.out
+[ ! -e "$GROK_BOT_WORKFLOWS/goal-flight/SKILL.md" ] || fail "grok-bot uninstall left skill"
 
 echo "goal-flight setup registrar tests passed"

--- a/tests/bash/test-goalflight-setup.sh
+++ b/tests/bash/test-goalflight-setup.sh
@@ -489,26 +489,4 @@ if python3 "$REPO_ROOT/scripts/goalflight_setup.py" --repo-root "$FIXTURE_REPO" 
 fi
 grep -q 'refusing ungated write action' /tmp/goal-flight-setup-ungated.out || fail "ungated write refusal missing"
 
-GROK_BOT_WORKFLOWS="$TMP_ROOT/grok-bot-workflows"
-mkdir -p "$GROK_BOT_WORKFLOWS"
-grok_bot_dry="$(GOALFLIGHT_GROK_BOT_WORKFLOWS="$GROK_BOT_WORKFLOWS" run_setup --grok-bot --addons '')"
-printf '%s\n' "$grok_bot_dry" | grep -q 'DRY-RUN setup agent=grok-bot' || fail "grok-bot dry-run header missing"
-printf '%s\n' "$grok_bot_dry" | grep -q 'DESTINATIONS selected=grok-bot-workflows-controller' || fail "grok-bot shortcut should select workflows controller"
-printf '%s\n' "$grok_bot_dry" | grep -q 'CONTROLLER_SURFACE grok-bot desktop' || fail "grok-bot controller surface missing"
-printf '%s\n' "$grok_bot_dry" | grep -q "configs/grok-bot/skills/goal-flight/SKILL.md" || fail "grok-bot wrapper source missing"
-printf '%s\n' "$grok_bot_dry" | grep -q "$GROK_BOT_WORKFLOWS/goal-flight/SKILL.md" || fail "grok-bot workflows target missing"
-printf '%s\n' "$grok_bot_dry" | grep -q 'PLUGIN skip supported=false' || fail "grok-bot plugin must stay skipped"
-if printf '%s\n' "$grok_bot_dry" | grep -q 'WORKER_CHECK'; then
-  fail "grok-bot controller-only setup should not plan a worker check"
-fi
-[ ! -e "$GROK_BOT_WORKFLOWS/goal-flight/SKILL.md" ] || fail "dry-run mutated grok-bot workflows skill"
-install_grok_bot_alias_dry="$(bash "$REPO_ROOT/install.sh" --grok-bot --addons '')"
-printf '%s\n' "$install_grok_bot_alias_dry" | grep -q 'DRY-RUN setup agent=grok-bot' || fail "install.sh --grok-bot alias did not select grok-bot setup"
-grok_bot_apply="$(GOALFLIGHT_GROK_BOT_WORKFLOWS="$GROK_BOT_WORKFLOWS" run_setup --apply --yes --grok-bot --addons '')"
-grok_bot_manifest="$(printf '%s\n' "$grok_bot_apply" | awk '/^BACKUP_MANIFEST /{print $2}')"
-[ -f "$GROK_BOT_WORKFLOWS/goal-flight/SKILL.md" ] || fail "grok-bot skill not installed"
-grep -q 'Grok Bot' "$GROK_BOT_WORKFLOWS/goal-flight/SKILL.md" || fail "grok-bot skill content missing"
-run_setup --uninstall --from-manifest "$grok_bot_manifest" >/tmp/goal-flight-setup-grok-bot-uninstall.out
-[ ! -e "$GROK_BOT_WORKFLOWS/goal-flight/SKILL.md" ] || fail "grok-bot uninstall left skill"
-
 echo "goal-flight setup registrar tests passed"

--- a/tests/bash/test-install-grok-bot.sh
+++ b/tests/bash/test-install-grok-bot.sh
@@ -373,4 +373,41 @@ if grep -q 'PostToolUse' "$REPO_ROOT/scripts/goalflight_grok_bot_listen.py"; the
 fi
 echo "test11 pass: grok-bot uses listen-exit quote-check, not a context meter"
 
+for mail_file in "$wrapper" "$host_doc"; do
+  grep -q 'post --to-controller' "$mail_file" \
+    || fail "$mail_file must make post --to-controller the inter-controller inbox"
+  grep -q 'Do not ask the user to paste' "$mail_file" \
+    || fail "$mail_file must forbid asking the user to paste mail"
+  grep -q 'check mail' "$mail_file" \
+    || fail "$mail_file must forbid asking the user to tell another session to check mail"
+  grep -q 'never the work inbox' "$mail_file" \
+    || fail "$mail_file must keep SendToAgent out of the work inbox"
+  grep -q 'battery-\*' "$mail_file" \
+    || fail "$mail_file must forbid SendToAgent as a bridge to battery-* controllers"
+  grep -q 'not user-as-mailman' "$mail_file" \
+    || fail "$mail_file must treat deafness as re-arm listen, not user-as-mailman"
+done
+python3 - "$REPO_ROOT" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+mail = json.loads((root / "adapters" / "grok-bot.json").read_text())["host_projection"]["mail"]
+if mail.get("inter_controller") != "goalflight_messages.py post --to-controller":
+    raise SystemExit("inter-controller traffic must be post --to-controller")
+if mail.get("send_to_agent_is_work_inbox") is not False:
+    raise SystemExit("SendToAgent must not be the work inbox")
+if mail.get("send_to_agent_bridges_battery_controllers") is not False:
+    raise SystemExit("SendToAgent must not bridge battery-* controllers")
+if "user-as-mailman" not in str(mail.get("deafness") or ""):
+    raise SystemExit("deafness must be re-arm listen, not user-as-mailman")
+forbidden = " ".join(mail.get("not") or [])
+if "paste mail" not in forbidden:
+    raise SystemExit("must not ask the user to paste mail")
+if "check mail" not in forbidden:
+    raise SystemExit("must not ask the user to tell another session to check mail")
+PY
+echo "test12 pass: grok-bot inter-controller mail is journal-only; user is the former mailman"
+
 echo "goal-flight grok-bot host install tests passed"

--- a/tests/bash/test-install-grok-bot.sh
+++ b/tests/bash/test-install-grok-bot.sh
@@ -154,16 +154,18 @@ from pathlib import Path
 
 root = Path(sys.argv[1])
 wake = json.loads((root / "adapters" / "grok-bot.json").read_text())["host_projection"]["wake"]
-if wake.get("path") != "goalflight_messages.py listen --report-pending --timeout-s 900":
-    raise SystemExit("host_projection.wake.path must be listen --report-pending --timeout-s 900")
+if wake.get("path") != "goalflight_grok_bot_listen.py --report-pending --timeout-s 900":
+    raise SystemExit("host_projection.wake.path must be goalflight_grok_bot_listen.py --report-pending --timeout-s 900")
 if wake.get("contract") != "exit-as-wake":
     raise SystemExit("host_projection.wake.contract must be exit-as-wake")
 if wake.get("controller_label") != "goalflight-grokbot":
     raise SystemExit("wake.controller_label must be goalflight-grokbot")
 if wake.get("timeout_s") != 900:
     raise SystemExit("wake.timeout_s must be 900")
-if wake.get("on_timeout") != "handoff write + status + task next, re-arm":
-    raise SystemExit("wake.on_timeout must write handoff, then status + task next, re-arm")
+if "quote-check" not in str(wake.get("on_ring") or ""):
+    raise SystemExit("wake.on_ring must quote-check after a ring")
+if wake.get("on_timeout") != "handoff write, quote-check, re-arm, task next":
+    raise SystemExit("wake.on_timeout must write handoff, quote-check, re-arm, task next")
 if wake.get("mvp_depth") != 1 or wake.get("full_depth") != 4:
     raise SystemExit("wake depth must be MVP 1 / full 4")
 if wake.get("finished_alias"):
@@ -287,6 +289,16 @@ if compact.get("no_task_tables_in_resume_notes") is not True:
     raise SystemExit("RESUME-NOTES must not carry task tables")
 if "before long waves" not in " ".join(compact.get("write_on") or []):
     raise SystemExit("must write handoff before long waves")
+if compact.get("strategy") != "autocompact + keep handoff current":
+    raise SystemExit("grok-bot strategy must be autocompact + keep handoff current")
+if compact.get("context_meter") is not False:
+    raise SystemExit("must not port the Claude context-meter")
+if compact.get("session_start_hook") is not False:
+    raise SystemExit("must not add a SessionStart hook on grok-bot")
+if compact.get("eighty_percent_substitute") != "listen --timeout-s 900":
+    raise SystemExit("900s listen timeout is the 80% hint substitute")
+if compact.get("mini_resume_on_wake") is not True:
+    raise SystemExit("every listen wake must be a mini-resume")
 forbidden = " ".join(compact.get("not") or [])
 if "invent a compact UI" not in forbidden:
     raise SystemExit("must not invent a compact UI")
@@ -294,7 +306,53 @@ if "ask the user to compact" not in forbidden:
     raise SystemExit("must not ask the user to compact")
 if "emulate Claude compact prompt" not in forbidden:
     raise SystemExit("must not emulate Claude compact prompt")
+if "goalflight-context-meter.sh" not in forbidden:
+    raise SystemExit("must refuse porting goalflight-context-meter.sh")
+if "fake window-percent meter" not in forbidden:
+    raise SystemExit("must refuse a fake window-percent meter")
 PY
 echo "test10 pass: grok-bot compaction is write-early handoff, not /compact"
+
+for meter_file in "$wrapper" "$host_doc"; do
+  grep -q 'autocompact + keep handoff current' "$meter_file" \
+    || fail "$meter_file must choose autocompact + keep handoff current"
+  grep -q 'goalflight-context-meter.sh' "$meter_file" \
+    || fail "$meter_file must name the Claude context-meter only to refuse it"
+  grep -q 'SessionStart' "$meter_file" \
+    || fail "$meter_file must refuse a SessionStart hook"
+  grep -q 'QUOTE-CHECK:' "$meter_file" \
+    || fail "$meter_file must externalize the Hard Invariants quote-check banner"
+  grep -q 'goalflight_grok_bot_listen.py' "$meter_file" \
+    || fail "$meter_file must arm the grok-bot listen wrapper"
+  grep -q 'mini-resume' "$meter_file" \
+    || fail "$meter_file must treat every listen wake as a mini-resume"
+  grep -q '80%' "$meter_file" \
+    || fail "$meter_file must name the 900s timeout as the 80% hint substitute"
+done
+banner_out="$(python3 "$REPO_ROOT/scripts/goalflight_grok_bot_listen.py" --help 2>&1)" || true
+printf '%s\n' "$banner_out" | grep -q 'QUOTE-CHECK: disk-read SKILL.md Hard Invariants' \
+  || fail "goalflight_grok_bot_listen.py must print the quote-check banner after listen exits"
+python3 - "$REPO_ROOT" <<'PY'
+import importlib.util
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+path = root / "scripts" / "goalflight_grok_bot_listen.py"
+spec = importlib.util.spec_from_file_location("grok_bot_listen", path)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+if mod._with_host_timeout([]) != ["--timeout-s", "900"]:
+    raise SystemExit("grok-bot listen wrapper must default --timeout-s 900")
+if mod._with_host_timeout(["--timeout-s", "0"]) != ["--timeout-s", "0"]:
+    raise SystemExit("explicit --timeout-s 0 must stay mail-only")
+if mod._with_host_timeout(["--timeout-s=0"]) != ["--timeout-s=0"]:
+    raise SystemExit("equals-form --timeout-s=0 must not be rewritten")
+PY
+if grep -q 'PostToolUse' "$REPO_ROOT/scripts/goalflight_grok_bot_listen.py"; then
+  grep -q 'Do not port' "$REPO_ROOT/scripts/goalflight_grok_bot_listen.py" \
+    || fail "listen wrapper must not implement PostToolUse"
+fi
+echo "test11 pass: grok-bot uses listen-exit quote-check, not a context meter"
 
 echo "goal-flight grok-bot host install tests passed"

--- a/tests/bash/test-install-grok-bot.sh
+++ b/tests/bash/test-install-grok-bot.sh
@@ -162,8 +162,8 @@ if wake.get("controller_label") != "goalflight-grokbot":
     raise SystemExit("wake.controller_label must be goalflight-grokbot")
 if wake.get("timeout_s") != 900:
     raise SystemExit("wake.timeout_s must be 900")
-if wake.get("on_timeout") != "status + task next, re-arm":
-    raise SystemExit("wake.on_timeout must pull status + task next, then re-arm")
+if wake.get("on_timeout") != "handoff write + status + task next, re-arm":
+    raise SystemExit("wake.on_timeout must write handoff, then status + task next, re-arm")
 if wake.get("mvp_depth") != 1 or wake.get("full_depth") != 4:
     raise SystemExit("wake depth must be MVP 1 / full 4")
 if wake.get("finished_alias"):
@@ -229,5 +229,72 @@ if pkg.get("no_parallel_package_format") is not True:
     raise SystemExit("must refuse a parallel package format")
 PY
 echo "test9 pass: grok-executor Task prompts reuse the Claude host-subagent pin"
+
+for compact_file in "$wrapper" "$host_doc"; do
+  grep -q 'protocols/state-handoff.md' "$compact_file" \
+    || fail "$compact_file must map directed compact to state-handoff.md"
+  grep -q 'Before compact or sleep' "$compact_file" \
+    || fail "$compact_file must name the Before compact or sleep write"
+  grep -q 'ENVIRONMENT' "$compact_file" \
+    || fail "$compact_file must name ENVIRONMENT in RESUME-NOTES slots"
+  grep -q 'IDEAS' "$compact_file" \
+    || fail "$compact_file must name IDEAS in RESUME-NOTES slots"
+  grep -q 'DECISIONS' "$compact_file" \
+    || fail "$compact_file must name DECISIONS in RESUME-NOTES slots"
+  grep -q 'FACTS' "$compact_file" \
+    || fail "$compact_file must name FACTS in RESUME-NOTES slots"
+  grep -q 'CARRIERS' "$compact_file" \
+    || fail "$compact_file must name CARRIERS in RESUME-NOTES slots"
+  grep -q 'no task tables' "$compact_file" \
+    || fail "$compact_file must forbid task tables in RESUME-NOTES"
+  grep -q 'before long waves' "$compact_file" \
+    || fail "$compact_file must write handoff before long waves"
+  grep -q 'keep-vs-toss' "$compact_file" \
+    || fail "$compact_file must state there is no keep-vs-toss prompt"
+  grep -q 'Do not ask the user to compact' "$compact_file" \
+    || fail "$compact_file must forbid asking the user to compact"
+  grep -q 'Do not invent a compact UI' "$compact_file" \
+    || fail "$compact_file must forbid inventing a compact UI"
+  grep -q 'Skip' "$compact_file" \
+    || fail "$compact_file must skip resume.md STEP 1.5 supervise"
+  grep -q 'Chat summaries are hints' "$compact_file" \
+    || fail "$compact_file must treat chat summaries as hints"
+  grep -q 'Hard Invariants' "$compact_file" \
+    || fail "$compact_file must require a fresh SKILL.md Hard Invariants disk read"
+  grep -q 'update_state' "$compact_file" \
+    || fail "$compact_file must call host profile/update_state/routines advisory"
+done
+python3 - "$REPO_ROOT" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+compact = json.loads((root / "adapters" / "grok-bot.json").read_text())["host_projection"]["compaction"]
+if compact.get("controller_authored_compact") is not False:
+    raise SystemExit("grok-bot has no controller-authored /compact")
+if compact.get("keep_vs_toss_prompt") is not False:
+    raise SystemExit("grok-bot has no keep-vs-toss prompt")
+if compact.get("host_may_summarize_unannounced") is not True:
+    raise SystemExit("host may summarize unannounced")
+if "Before compact or sleep" not in str(compact.get("directed_compact_is") or ""):
+    raise SystemExit("directed compact is the state-handoff Before compact write")
+if compact.get("canonical_memory") != "repo_files":
+    raise SystemExit("canonical memory remains repo_files")
+if "STEP 1.5" not in str(compact.get("resume_wake") or ""):
+    raise SystemExit("resume_wake must skip commands/resume.md STEP 1.5")
+if compact.get("no_task_tables_in_resume_notes") is not True:
+    raise SystemExit("RESUME-NOTES must not carry task tables")
+if "before long waves" not in " ".join(compact.get("write_on") or []):
+    raise SystemExit("must write handoff before long waves")
+forbidden = " ".join(compact.get("not") or [])
+if "invent a compact UI" not in forbidden:
+    raise SystemExit("must not invent a compact UI")
+if "ask the user to compact" not in forbidden:
+    raise SystemExit("must not ask the user to compact")
+if "emulate Claude compact prompt" not in forbidden:
+    raise SystemExit("must not emulate Claude compact prompt")
+PY
+echo "test10 pass: grok-bot compaction is write-early handoff, not /compact"
 
 echo "goal-flight grok-bot host install tests passed"

--- a/tests/bash/test-install-grok-bot.sh
+++ b/tests/bash/test-install-grok-bot.sh
@@ -180,4 +180,54 @@ if "global supervise/follow cadence change" not in forbidden:
 PY
 echo "test8 pass: grok-bot wake path is listen doorbell + 900s frontier ping"
 
+for ctx_file in "$wrapper" "$host_doc"; do
+  grep -q 'protocols/subagent-preamble.md' "$ctx_file" \
+    || fail "$ctx_file must open executor prompts with subagent-preamble.md"
+  grep -q 'protocols/worker-context-package.md' "$ctx_file" \
+    || fail "$ctx_file must apply worker-context-package.md when the lane is triggered"
+  grep -Ei 'if the lane is triggered|If the lane is triggered' "$ctx_file" >/dev/null \
+    || fail "$ctx_file must gate the lane package on a trigger, not apply it always"
+  grep -q 'docs-private/rag/ORIENTATION.md' "$ctx_file" \
+    || fail "$ctx_file must pointer to rag/ORIENTATION.md when present"
+  grep -q 'machineId' "$ctx_file" \
+    || fail "$ctx_file must name machineId for grok-executor Mac targeting"
+  grep -q '/Users/simonrowland/Repos' "$ctx_file" \
+    || fail "$ctx_file must cite Mac absolute paths under /Users/simonrowland/Repos"
+  grep -q -- '--prompt-file' "$ctx_file" \
+    || fail "$ctx_file must keep five-layer --prompt-file for CLI and paste it for executors"
+  if grep -qi 'parallel package' "$ctx_file"; then
+    :
+  else
+    fail "$ctx_file must refuse a parallel executor package format"
+  fi
+done
+[ ! -e "$REPO_ROOT/templates/grok-executor-prompt.md.tpl" ] \
+  || fail "do not add a grok-executor template; Cursor/Grok CLI wrappers have none"
+python3 - "$REPO_ROOT" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+routing = json.loads((root / "adapters" / "grok-bot.json").read_text())["host_projection"]["routing"]
+pkg = routing.get("executor_context_package") or {}
+if "protocols/subagent-preamble.md" not in (pkg.get("reuse") or []):
+    raise SystemExit("executor_context_package must reuse subagent-preamble.md")
+if pkg.get("triggered_lane_package") != "protocols/worker-context-package.md":
+    raise SystemExit("triggered_lane_package must be worker-context-package.md")
+if "protocols/worker-context-package.md" in (pkg.get("reuse") or []):
+    raise SystemExit("do not always-on reuse the lane package; it is trigger-gated")
+if pkg.get("default_computer") != "Grok Bot box":
+    raise SystemExit("executors default to the Grok Bot box")
+if pkg.get("work_computer") != "user registered computer via machineId":
+    raise SystemExit("executor work computer must be the user Mac via machineId")
+if not str(pkg.get("mac_path_prefix") or "").startswith("/Users/simonrowland/Repos"):
+    raise SystemExit("mac_path_prefix must be /Users/simonrowland/Repos/")
+if pkg.get("no_clone_onto_box") is not True:
+    raise SystemExit("must forbid cloning onto the Grok Bot box")
+if pkg.get("no_parallel_package_format") is not True:
+    raise SystemExit("must refuse a parallel package format")
+PY
+echo "test9 pass: grok-executor Task prompts reuse the Claude host-subagent pin"
+
 echo "goal-flight grok-bot host install tests passed"

--- a/tests/bash/test-install-grok-bot.sh
+++ b/tests/bash/test-install-grok-bot.sh
@@ -265,7 +265,17 @@ for compact_file in "$wrapper" "$host_doc"; do
     || fail "$compact_file must require a fresh SKILL.md Hard Invariants disk read"
   grep -q 'update_state' "$compact_file" \
     || fail "$compact_file must call host profile/update_state/routines advisory"
+  grep -q 'not the compaction mailman' "$compact_file" \
+    || fail "$compact_file must keep the operator off compaction"
+  grep -q 'wake unarmed' "$compact_file" \
+    || fail "$compact_file must surface wake-hygiene as roster wake unarmed"
+  grep -q 'exit 5' "$compact_file" \
+    || fail "$compact_file must map token-pause/update to listen exit 5"
+  grep -q 'second reminder channel' "$compact_file" \
+    || fail "$compact_file must refuse a second reminder channel"
 done
+grep -q '## Operator role' "$host_doc" \
+  || fail "docs/hosts/grok-bot.md must have an Operator role section"
 python3 - "$REPO_ROOT" <<'PY'
 import json
 import sys
@@ -310,6 +320,14 @@ if "goalflight-context-meter.sh" not in forbidden:
     raise SystemExit("must refuse porting goalflight-context-meter.sh")
 if "fake window-percent meter" not in forbidden:
     raise SystemExit("must refuse a fake window-percent meter")
+if compact.get("operator_is_compaction_mailman") is not False:
+    raise SystemExit("operator is not the compaction mailman")
+if compact.get("no_second_reminder_channel") is not True:
+    raise SystemExit("must not invent a second reminder channel")
+if "wake unarmed" not in str(compact.get("operator_signal") or ""):
+    raise SystemExit("operator signal must be roster wake unarmed")
+if "exit 5" not in str(compact.get("token_pause_or_update") or ""):
+    raise SystemExit("token-pause/update must map to listen exit 5")
 PY
 echo "test10 pass: grok-bot compaction is write-early handoff, not /compact"
 

--- a/tests/bash/test-install-grok-bot.sh
+++ b/tests/bash/test-install-grok-bot.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Hermetic grok-bot host-port install: dry-run, apply, uninstall.
+# Does not require a Grok Bot box, Grok CLI, or other host binaries.
+
+set -eu
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/goal-flight-grok-bot-test.XXXXXX")"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+export HOME="$TMP_ROOT/home"
+export XDG_STATE_HOME="$TMP_ROOT/state"
+export GOALFLIGHT_SKIP_ACP_VENV_SETUP=1
+export GOALFLIGHT_GROK_BOT_WORKFLOWS="$TMP_ROOT/workflows"
+mkdir -p "$HOME" "$GOALFLIGHT_GROK_BOT_WORKFLOWS"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+run_setup() {
+  bash "$REPO_ROOT/setup.sh" "$@"
+}
+
+list_out="$(run_setup --list-agents)"
+printf '%s\n' "$list_out" | grep -q 'controller grok-bot-workflows-controller' \
+  || fail "grok-bot controller not listed"
+
+grok_bot_dry="$(run_setup --grok-bot --addons '')"
+printf '%s\n' "$grok_bot_dry" | grep -q 'DRY-RUN setup agent=grok-bot' \
+  || fail "grok-bot dry-run header missing"
+printf '%s\n' "$grok_bot_dry" | grep -q 'DESTINATIONS selected=grok-bot-workflows-controller' \
+  || fail "grok-bot shortcut should select workflows controller"
+printf '%s\n' "$grok_bot_dry" | grep -q 'CONTROLLER_SURFACE grok-bot desktop' \
+  || fail "grok-bot controller surface missing"
+printf '%s\n' "$grok_bot_dry" | grep -q "configs/grok-bot/skills/goal-flight/SKILL.md" \
+  || fail "grok-bot wrapper source missing"
+printf '%s\n' "$grok_bot_dry" | grep -q "$GOALFLIGHT_GROK_BOT_WORKFLOWS/goal-flight/SKILL.md" \
+  || fail "grok-bot workflows target missing"
+printf '%s\n' "$grok_bot_dry" | grep -q 'PLUGIN skip supported=false' \
+  || fail "grok-bot plugin must stay skipped"
+if printf '%s\n' "$grok_bot_dry" | grep -q 'WORKER_CHECK'; then
+  fail "grok-bot controller-only setup should not plan a worker check"
+fi
+[ ! -e "$GOALFLIGHT_GROK_BOT_WORKFLOWS/goal-flight/SKILL.md" ] \
+  || fail "dry-run mutated grok-bot workflows skill"
+echo "test1 pass: grok-bot dry-run plans wrapper copy and mutates nothing"
+
+install_alias_dry="$(bash "$REPO_ROOT/install.sh" --grok-bot --addons '')"
+printf '%s\n' "$install_alias_dry" | grep -q 'DRY-RUN setup agent=grok-bot' \
+  || fail "install.sh --grok-bot alias did not select grok-bot setup"
+echo "test2 pass: install.sh --grok-bot is a dry-run alias"
+
+agent_dry="$(run_setup --agent grok-bot --addons '')"
+printf '%s\n' "$agent_dry" | grep -q 'DRY-RUN setup agent=grok-bot' \
+  || fail "--agent grok-bot dry-run header missing"
+printf '%s\n' "$agent_dry" | grep -q "$GOALFLIGHT_GROK_BOT_WORKFLOWS/goal-flight/SKILL.md" \
+  || fail "--agent grok-bot should expand the workflows target"
+echo "test3 pass: --agent grok-bot selects the default controller destination"
+
+grok_bot_apply="$(run_setup --apply --yes --grok-bot --addons '')"
+printf '%s\n' "$grok_bot_apply" | grep -q '^APPLY ' \
+  || fail "grok-bot apply should write the wrapper"
+grok_bot_manifest="$(printf '%s\n' "$grok_bot_apply" | awk '/^BACKUP_MANIFEST /{print $2}')"
+[ -n "$grok_bot_manifest" ] || fail "grok-bot backup manifest path missing"
+[ -f "$GOALFLIGHT_GROK_BOT_WORKFLOWS/goal-flight/SKILL.md" ] \
+  || fail "grok-bot skill not installed"
+grep -q 'Grok Bot' "$GOALFLIGHT_GROK_BOT_WORKFLOWS/goal-flight/SKILL.md" \
+  || fail "grok-bot skill content missing"
+echo "test4 pass: apply writes the workflows-library wrapper"
+
+oneshot_root="$TMP_ROOT/oneshot-workflows"
+oneshot_out="$(bash "$REPO_ROOT/install.sh" grok-bot "$oneshot_root" --addons '' 2>&1)"
+printf '%s\n' "$oneshot_out" | grep -q '^APPLY ' \
+  || fail "install.sh grok-bot <root> should apply writes"
+[ -f "$oneshot_root/goal-flight/SKILL.md" ] \
+  || fail "install.sh grok-bot oneshot did not write SKILL.md"
+echo "test5 pass: install.sh grok-bot <workflows-root> applies"
+
+run_setup --uninstall --from-manifest "$grok_bot_manifest" \
+  >/tmp/goal-flight-setup-grok-bot-uninstall.out
+[ ! -e "$GOALFLIGHT_GROK_BOT_WORKFLOWS/goal-flight/SKILL.md" ] \
+  || fail "grok-bot uninstall left skill"
+echo "test6 pass: uninstall restores the workflows library"
+
+echo "goal-flight grok-bot host install tests passed"

--- a/tests/bash/test-install-grok-bot.sh
+++ b/tests/bash/test-install-grok-bot.sh
@@ -84,4 +84,37 @@ run_setup --uninstall --from-manifest "$grok_bot_manifest" \
   || fail "grok-bot uninstall left skill"
 echo "test6 pass: uninstall restores the workflows library"
 
+wrapper="$REPO_ROOT/configs/grok-bot/skills/goal-flight/SKILL.md"
+if grep -q 'LAST RESORT' "$wrapper"; then
+  fail "grok-bot wrapper must not copy the Claude-host LAST RESORT executor rule"
+fi
+grep -q 'first-class' "$wrapper" \
+  || fail "grok-bot wrapper must call Executors first-class"
+grep -q -- '--agent moonshot' "$wrapper" \
+  || fail "grok-bot wrapper must route kimi3 reviews through --agent moonshot"
+python3 - "$REPO_ROOT" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+manifest = json.loads((root / "adapters" / "grok-bot.json").read_text())
+delegate = manifest["tool_name_map"]["delegate"]
+if "Grok Bot Task/executor" not in delegate["host_tools"]:
+    raise SystemExit("delegate host_tools must name Grok Bot Task/executor")
+joined = " ".join(delegate["constraints"])
+if "first-class" not in joined:
+    raise SystemExit("delegate constraints must call Executor first-class")
+if "last-resort" not in joined:
+    raise SystemExit("delegate constraints must reject last-resort framing")
+if "moonshot" not in joined:
+    raise SystemExit("delegate constraints must name --agent moonshot for kimi3")
+routing = manifest.get("host_projection", {}).get("routing") or {}
+if routing.get("executor_is_first_class") is not True:
+    raise SystemExit("host_projection.routing.executor_is_first_class must be true")
+if "kimi3" in json.dumps(manifest.get("agent_id")):
+    raise SystemExit("must not invent a kimi3 agent_id")
+PY
+echo "test7 pass: grok-bot routing treats Executor as first-class; kimi3 is moonshot"
+
 echo "goal-flight grok-bot host install tests passed"

--- a/tests/bash/test-install-grok-bot.sh
+++ b/tests/bash/test-install-grok-bot.sh
@@ -121,20 +121,30 @@ host_doc="$REPO_ROOT/docs/hosts/grok-bot.md"
 for wake_file in "$wrapper" "$host_doc"; do
   grep -q 'listen --report-pending' "$wake_file" \
     || fail "$wake_file must arm listen --report-pending"
+  grep -q -- '--timeout-s 900' "$wake_file" \
+    || fail "$wake_file must default listen --timeout-s 900"
+  grep -q 'goalflight-grokbot' "$wake_file" \
+    || fail "$wake_file must claim controller label goalflight-grokbot"
   grep -q 'relay --drain' "$wake_file" \
     || fail "$wake_file must drain on ring with relay --drain"
   grep -q '!COMPLETE' "$wake_file" \
-    || fail "$wake_file must name !COMPLETE as a worker terminal"
-  grep -E 'no `!FINISHED`|There is no `!FINISHED`' "$wake_file" >/dev/null \
-    || fail "$wake_file must reject !FINISHED as a first-class marker"
-  grep -Ei 'alias|treat it as `!COMPLETE`' "$wake_file" >/dev/null \
-    || fail "$wake_file must alias FINISHED to !COMPLETE"
+    || fail "$wake_file must name !COMPLETE as the success terminal"
+  grep -E 'exit 1|timeout \(exit 1\)' "$wake_file" >/dev/null \
+    || fail "$wake_file must treat listen exit 1 as the frontier reminder"
+  grep -q 'goalflight_task.py next' "$wake_file" \
+    || fail "$wake_file must pull task next on the 900s frontier ping"
+  if grep -q '!FINISHED' "$wake_file"; then
+    fail "$wake_file must not reify the misremembered !FINISHED marker"
+  fi
   grep -q 'exit 4' "$wake_file" \
     || fail "$wake_file must refuse detached listen (exit 4)"
   if grep -E 'arm unbounded `supervise`|Do \*\*not\*\* arm unbounded `supervise`' "$wake_file" >/dev/null; then
     :
   else
     fail "$wake_file must forbid unbounded supervise as the grok-bot arm"
+  fi
+  if grep -E 'Supervise heartbeats \(~120s\)|supervise heartbeats \(~120s\)' "$wake_file" >/dev/null; then
+    fail "$wake_file must not treat the 120s Claude stream heartbeat as the grok-bot ping"
   fi
 done
 python3 - "$REPO_ROOT" <<'PY'
@@ -144,20 +154,30 @@ from pathlib import Path
 
 root = Path(sys.argv[1])
 wake = json.loads((root / "adapters" / "grok-bot.json").read_text())["host_projection"]["wake"]
-if wake.get("path") != "goalflight_messages.py listen --report-pending":
-    raise SystemExit("host_projection.wake.path must be listen --report-pending")
+if wake.get("path") != "goalflight_messages.py listen --report-pending --timeout-s 900":
+    raise SystemExit("host_projection.wake.path must be listen --report-pending --timeout-s 900")
 if wake.get("contract") != "exit-as-wake":
     raise SystemExit("host_projection.wake.contract must be exit-as-wake")
+if wake.get("controller_label") != "goalflight-grokbot":
+    raise SystemExit("wake.controller_label must be goalflight-grokbot")
+if wake.get("timeout_s") != 900:
+    raise SystemExit("wake.timeout_s must be 900")
+if wake.get("on_timeout") != "status + task next, re-arm":
+    raise SystemExit("wake.on_timeout must pull status + task next, then re-arm")
 if wake.get("mvp_depth") != 1 or wake.get("full_depth") != 4:
     raise SystemExit("wake depth must be MVP 1 / full 4")
-if wake.get("finished_alias") != "COMPLETE":
-    raise SystemExit("FINISHED must alias to COMPLETE")
+if wake.get("finished_alias"):
+    raise SystemExit("do not reify a FINISHED alias; success terminal is COMPLETE")
 if "native mail transport" not in " ".join(wake.get("not") or []):
     raise SystemExit("wake.not must keep native mail transport out of this port")
 forbidden = " ".join(wake.get("not") or [])
 if "unbounded supervise" not in forbidden:
     raise SystemExit("wake.not must forbid unbounded supervise")
+if "120s" not in forbidden:
+    raise SystemExit("wake.not must reject the 120s Claude stream heartbeat as a grok-bot arm")
+if "global supervise/follow cadence change" not in forbidden:
+    raise SystemExit("wake.not must keep the 900s timeout host-local")
 PY
-echo "test8 pass: grok-bot wake path is listen doorbell, not supervise or a new bus"
+echo "test8 pass: grok-bot wake path is listen doorbell + 900s frontier ping"
 
 echo "goal-flight grok-bot host install tests passed"

--- a/tests/bash/test-install-grok-bot.sh
+++ b/tests/bash/test-install-grok-bot.sh
@@ -360,12 +360,35 @@ path = root / "scripts" / "goalflight_grok_bot_listen.py"
 spec = importlib.util.spec_from_file_location("grok_bot_listen", path)
 mod = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(mod)
-if mod._with_host_timeout([]) != ["--timeout-s", "900"]:
-    raise SystemExit("grok-bot listen wrapper must default --timeout-s 900")
-if mod._with_host_timeout(["--timeout-s", "0"]) != ["--timeout-s", "0"]:
+defaults = mod._with_host_defaults([])
+if defaults != [
+    "--timeout-s",
+    "900",
+    "--controller-label",
+    "goalflight-grokbot",
+    "--report-pending",
+]:
+    raise SystemExit(f"bare helper must inject timeout, label, report-pending; got {defaults}")
+if mod._with_host_timeout([]) != defaults:
+    raise SystemExit("_with_host_timeout must alias _with_host_defaults")
+timeout_override = mod._with_host_defaults(["--timeout-s", "0"])
+if "--timeout-s" not in timeout_override or timeout_override[timeout_override.index("--timeout-s") + 1] != "0":
     raise SystemExit("explicit --timeout-s 0 must stay mail-only")
-if mod._with_host_timeout(["--timeout-s=0"]) != ["--timeout-s=0"]:
+if "--controller-label" not in timeout_override or "goalflight-grokbot" not in timeout_override:
+    raise SystemExit("timeout override must still default controller-label")
+if "--report-pending" not in timeout_override:
+    raise SystemExit("timeout override must still default --report-pending")
+if mod._with_host_defaults(["--timeout-s=0"])[0] != "--timeout-s=0":
     raise SystemExit("equals-form --timeout-s=0 must not be rewritten")
+label_override = mod._with_host_defaults(["--controller-label", "other-slug"])
+if label_override.count("--controller-label") != 1 or "other-slug" not in label_override:
+    raise SystemExit("explicit --controller-label must win")
+if "goalflight-grokbot" in label_override:
+    raise SystemExit("must not inject goalflight-grokbot over an explicit label")
+if "--no-report-pending" not in mod._with_host_defaults(["--no-report-pending"]):
+    raise SystemExit("explicit --no-report-pending must be honored")
+if "--report-pending" in mod._with_host_defaults(["--no-report-pending"]):
+    raise SystemExit("must not inject --report-pending over --no-report-pending")
 PY
 if grep -q 'PostToolUse' "$REPO_ROOT/scripts/goalflight_grok_bot_listen.py"; then
   grep -q 'Do not port' "$REPO_ROOT/scripts/goalflight_grok_bot_listen.py" \
@@ -409,5 +432,40 @@ if "check mail" not in forbidden:
     raise SystemExit("must not ask the user to tell another session to check mail")
 PY
 echo "test12 pass: grok-bot inter-controller mail is journal-only; user is the former mailman"
+
+grep -q -- '--controller-pid <pid>' "$wrapper" \
+  || fail "wrapper dispatch stamp must include --controller-pid <pid>"
+grep -q -- '--controller-session-id <session-id>' "$wrapper" \
+  || fail "wrapper dispatch stamp must include --controller-session-id <session-id>"
+grep -q '~/.goal-flight/skill/scripts' "$wrapper" \
+  || fail "wrapper must run scripts from the skill pin scripts directory"
+grep -q 'GOALFLIGHT_GROK_BOT_WORKFLOWS' "$REPO_ROOT/README.md" \
+  || fail "README must caveat Mac grok-bot install with GOALFLIGHT_GROK_BOT_WORKFLOWS"
+grep -q 'does not invent a second Mac default' "$REPO_ROOT/README.md" \
+  || fail "README must refuse a second Mac default workflows root"
+grep -q 'check drift on the box' "$REPO_ROOT/README.md" \
+  || fail "README must say grok-bot drift check is box-side"
+grep -q 'default gstack and autoreview addons' "$wrapper" \
+  || fail "wrapper must note bare install applies default addons"
+python3 - "$REPO_ROOT" <<'PY'
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+sys.path.insert(0, str(root / "scripts"))
+import goalflight_setup as mod
+
+if mod._grok_bot_mac_default_warn(platform="linux", env={}) is not None:
+    raise SystemExit("Darwin warn must stay silent on linux")
+warn = mod._grok_bot_mac_default_warn(platform="darwin", env={})
+if not warn or "/home/box/agent-data/workflows" not in warn:
+    raise SystemExit("Darwin + default box path must warn")
+if mod._grok_bot_mac_default_warn(
+    platform="darwin",
+    env={"GOALFLIGHT_GROK_BOT_WORKFLOWS": "/tmp/workflows"},
+) is not None:
+    raise SystemExit("Darwin warn must stay silent when override is set")
+PY
+echo "test13 pass: grok-bot helper defaults, Mac install caveat, and dispatch stamp"
 
 echo "goal-flight grok-bot host install tests passed"

--- a/tests/bash/test-install-grok-bot.sh
+++ b/tests/bash/test-install-grok-bot.sh
@@ -117,4 +117,47 @@ if "kimi3" in json.dumps(manifest.get("agent_id")):
 PY
 echo "test7 pass: grok-bot routing treats Executor as first-class; kimi3 is moonshot"
 
+host_doc="$REPO_ROOT/docs/hosts/grok-bot.md"
+for wake_file in "$wrapper" "$host_doc"; do
+  grep -q 'listen --report-pending' "$wake_file" \
+    || fail "$wake_file must arm listen --report-pending"
+  grep -q 'relay --drain' "$wake_file" \
+    || fail "$wake_file must drain on ring with relay --drain"
+  grep -q '!COMPLETE' "$wake_file" \
+    || fail "$wake_file must name !COMPLETE as a worker terminal"
+  grep -E 'no `!FINISHED`|There is no `!FINISHED`' "$wake_file" >/dev/null \
+    || fail "$wake_file must reject !FINISHED as a first-class marker"
+  grep -Ei 'alias|treat it as `!COMPLETE`' "$wake_file" >/dev/null \
+    || fail "$wake_file must alias FINISHED to !COMPLETE"
+  grep -q 'exit 4' "$wake_file" \
+    || fail "$wake_file must refuse detached listen (exit 4)"
+  if grep -E 'arm unbounded `supervise`|Do \*\*not\*\* arm unbounded `supervise`' "$wake_file" >/dev/null; then
+    :
+  else
+    fail "$wake_file must forbid unbounded supervise as the grok-bot arm"
+  fi
+done
+python3 - "$REPO_ROOT" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+wake = json.loads((root / "adapters" / "grok-bot.json").read_text())["host_projection"]["wake"]
+if wake.get("path") != "goalflight_messages.py listen --report-pending":
+    raise SystemExit("host_projection.wake.path must be listen --report-pending")
+if wake.get("contract") != "exit-as-wake":
+    raise SystemExit("host_projection.wake.contract must be exit-as-wake")
+if wake.get("mvp_depth") != 1 or wake.get("full_depth") != 4:
+    raise SystemExit("wake depth must be MVP 1 / full 4")
+if wake.get("finished_alias") != "COMPLETE":
+    raise SystemExit("FINISHED must alias to COMPLETE")
+if "native mail transport" not in " ".join(wake.get("not") or []):
+    raise SystemExit("wake.not must keep native mail transport out of this port")
+forbidden = " ".join(wake.get("not") or [])
+if "unbounded supervise" not in forbidden:
+    raise SystemExit("wake.not must forbid unbounded supervise")
+PY
+echo "test8 pass: grok-bot wake path is listen doorbell, not supervise or a new bus"
+
 echo "goal-flight grok-bot host install tests passed"

--- a/tests/python/test_goalflight_procedural.py
+++ b/tests/python/test_goalflight_procedural.py
@@ -283,6 +283,7 @@ def test_doctor_json_shape() -> None:
     assert_true("plugin section", "plugin" in payload and "manifest_exists" in payload["plugin"])
     assert_true("host install section", "host_goalflight_install" in payload)
     assert_true("codex host install probe", "codex" in payload["host_goalflight_install"])
+    assert_true("grok-bot host install probe", "grok-bot" in payload["host_goalflight_install"])
     assert_true("installed skill drift section", "installed_skill_drift" in payload)
     isd = payload["installed_skill_drift"]
     for key in ("source_root", "source_root_hash", "entries", "drift"):
@@ -360,6 +361,46 @@ def test_doctor_json_shape() -> None:
 def _write_skill(path: Path, text: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(text)
+
+
+def test_installed_skill_drift_covers_grok_bot_copy() -> None:
+    old_home = os.environ.get("HOME")
+    old_workflows = os.environ.get("GOALFLIGHT_GROK_BOT_WORKFLOWS")
+    try:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            home = root / "home"
+            project = root / "project"
+            skill_root = root / "goal-flight"
+            workflows = root / "workflows"
+            os.environ["HOME"] = str(home)
+            os.environ["GOALFLIGHT_GROK_BOT_WORKFLOWS"] = str(workflows)
+            _write_skill(skill_root / "SKILL.md", "root skill\n")
+            _write_skill(skill_root / "plugins/goal-flight/skills/goal-flight/SKILL.md", "codex skill\n")
+            _write_skill(skill_root / "configs/cursor/skills/goal-flight/SKILL.md", "cursor skill\n")
+            _write_skill(skill_root / "configs/opencode/skills/goal-flight/SKILL.md", "opencode skill\n")
+            _write_skill(skill_root / "configs/grok/skills/goal-flight/SKILL.md", "grok skill\n")
+            _write_skill(skill_root / "configs/grok-bot/skills/goal-flight/SKILL.md", "grok-bot skill\n")
+            _write_skill(workflows / "goal-flight/SKILL.md", "old grok-bot skill\n")
+
+            payload = goalflight_doctor.check_installed_skill_drift(skill_root, project)
+            entries = {entry["path"]: entry for entry in payload["entries"]}
+            grok_bot_entry = entries[str(workflows / "goal-flight/SKILL.md")]
+            assert_true("grok-bot workflows copy detected", grok_bot_entry["host"] == "grok-bot")
+            assert_true("grok-bot stale copy warns", grok_bot_entry["drift"] is True)
+            assert_true(
+                "grok-bot resync names install.sh grok-bot",
+                grok_bot_entry["resync_command"] == "./install.sh grok-bot",
+            )
+    finally:
+        if old_home is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = old_home
+        if old_workflows is None:
+            os.environ.pop("GOALFLIGHT_GROK_BOT_WORKFLOWS", None)
+        else:
+            os.environ["GOALFLIGHT_GROK_BOT_WORKFLOWS"] = old_workflows
 
 
 def test_installed_skill_drift_covers_project_local_copy() -> None:
@@ -1713,6 +1754,7 @@ def main() -> None:
         test_ledger_record_finish_status,
         test_doctor_json_shape,
         test_installed_skill_drift_covers_project_local_copy,
+        test_installed_skill_drift_covers_grok_bot_copy,
         test_installed_skill_drift_allows_claude_link_mode,
         test_installed_skill_drift_project_symlink_stays_copy_mode,
         test_doctor_target_project_readiness_split,

--- a/tests/python/test_validate_adapters.py
+++ b/tests/python/test_validate_adapters.py
@@ -57,7 +57,7 @@ def case_cli_real_repo_silent_and_verbose() -> None:
     with redirect_stdout(out), redirect_stderr(err):
         rc = V.main(["--repo", str(ROOT), "--verbose"])
     assert rc == 0
-    assert out.getvalue() == "schema_validates=17/17\n"
+    assert out.getvalue() == "schema_validates=18/18\n"
     assert err.getvalue() == ""
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Thin Grok Bot controller port over the portable Goal Flight core. This is not a rewrite of the core and not a replacement for `adapters/grok.json` (`grok agent stdio`).

## What this adds

- Host wrapper at `configs/grok-bot/skills/goal-flight/SKILL.md`
- Controller-only adapter `adapters/grok-bot.json`
- `./install.sh grok-bot` copies the wrapper into the Grok Bot workflows library
- Host notes at `docs/hosts/grok-bot.md`
- Host-local listen helper `scripts/goalflight_grok_bot_listen.py`
- Hermetic coverage in `tests/bash/test-install-grok-bot.sh`

## Mail

The operator is the **former mailman**. Inter-controller traffic is only `goalflight_messages.py post --to-controller`. Grok-bot controllers join that journal. Do not ask the user to paste mail or to tell another session to check mail.

SendToAgent (Grok Bot teammate DMs) is an optional extra ping among grok-bot agents. It is never the work inbox and never the bridge to Claude `battery-*` controllers.

Deafness is re-arm listen, not user-as-mailman.

## Operator / compaction

The operator is not the compaction mailman. Autocompact plus the 15-minute doorbell mini-resume owns that job. The one wake-hygiene job is re-arming listen after a host update or token-pause, surfaced as roster `wake unarmed`.

## Review should-fixes (this push)

Independent file review of `gh pr diff` was merge-after-fixes with no locked-decision blockers. Applied on this branch:

- Bare `goalflight_grok_bot_listen.py` now injects `--timeout-s 900`, `--report-pending`, and `--controller-label goalflight-grokbot` (explicit flags win). Executable bit set.
- README / wrapper / host doc caveat the Mac-clone one-liner: default workflows root is the Grok Bot box path. Darwin warns when using that default. No second Mac library root. Doctor drift is box-side unless overridden.
- Wrapper dispatch stamp uses `--controller-pid <pid> --controller-session-id <session-id>`.
- Skill pin says run scripts from `$GOALFLIGHT_ROOT/scripts` or `~/.goal-flight/skill/scripts`.
- Bare install notes default gstack/autoreview addons (`--addons ''` skips).

## Test plan

- `bash tests/bash/test-install-grok-bot.sh`
- `bash tests/bash/test-agent-adapters.sh`
- `python3 scripts/goalflight_validate_adapters.py` (`schema_validates=18/18`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-62efa344-1c8c-4297-8fde-a07369fd9425?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62efa344-1c8c-4297-8fde-a07369fd9425&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

