### PR TITLE
Resume dispatch in the same worktree after quota death or plan approval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ incremented when meaningful skill behaviour changes.
 
 ### Fixed
 
+- `goalflight_dispatch.py resume` reattaches to the existing worktree instead
+  of acquiring a sibling pooled seat, so quota-exhausted / dead / plan-approval
+  pauses continue in place. `--account` is honored; default seat order skips
+  recently quota-exhausted accounts until their reset.
 - `supervise` backlog cap keys on envelope identity, not raw line count.
   Duplicate copies of one cursor snapshot still collapse as `cursor-lag` /
   `child-backlog`. Distinct envelopes (new cursor versions, unique headlines,

--- a/protocols/dispatch-resume.md
+++ b/protocols/dispatch-resume.md
@@ -43,7 +43,11 @@ you want to keep, not by what killed the worker.
   SAME engine session id. The child keeps `parent_dispatch_id` so ledger and
   journal stay one story. The Goal Flight launch id is new because each
   spawn is a new process, lease, and status file; the conversation handle is
-  not.
+  not. Resume reattaches to the existing worktree, branch, and partial
+  artifacts — it does not acquire a sibling pooled seat. Quota-exhausted,
+  dead-pid, stale_dead, and plan-approval pauses (USER-NEED / !READY) are
+  continuable. `--account <seat>` pins a surviving seat; default selection
+  skips recently quota-exhausted accounts until their reset.
 - Every wired worker CLI is resumable: Codex (`codex exec resume`), Grok
   (`--resume <id>`), cursor-agent (`--resume <chatId>`), Claude
   (`--resume <id>`), and Moonshot/Kimi (`-S <id>`). ACP dispatches resume

--- a/scripts/goalflight_dispatch.py
+++ b/scripts/goalflight_dispatch.py
@@ -1714,6 +1714,10 @@ def _bind_dispatch_worktree(args) -> goalflight_worktree_pool.WorktreeSeatLease 
     existing = getattr(args, "_worktree_seat", None)
     if existing is not None:
         return existing
+    if getattr(args, "parent_dispatch_id", None):
+        # Resume reattaches to the recorded worker_cwd. Acquiring a pooled
+        # seat here would mint a sibling tree and reset partial work.
+        return None
     base = _requested_worktree_base(args)
     if base is None:
         return None
@@ -3307,6 +3311,7 @@ def _worktree_incumbent_reason(args) -> tuple[str | None, str | None, str | None
     except OSError as exc:
         return None, f"dispatch ledger could not be read ({type(exc).__name__}: {exc})", None
     own_id = getattr(args, "dispatch_id", None)
+    parent_id = getattr(args, "parent_dispatch_id", None)
     host = socket.gethostname()
     unknown: list[str] = []
     for record in records:
@@ -3315,6 +3320,8 @@ def _worktree_incumbent_reason(args) -> tuple[str | None, str | None, str | None
         record_id = record.get("dispatch_id")
         if own_id and record_id == own_id:
             continue  # the drained/resumed launch re-enters with its own queued record
+        if parent_id and record_id == parent_id:
+            continue  # resume continues in the parent's tree, including plan-approval pauses
         if goalflight_ledger.record_is_unreadable(record):
             unknown.append(f"ledger record {record.get('path') or record_id} is unreadable")
             continue
@@ -4017,6 +4024,19 @@ def _assert_codex_resume_source_not_live(record: dict, dispatch_id: str) -> None
 
     source_state = status.get("state") or record.get("state")
     source_reason = status.get("reason") or record.get("reason")
+    source_classification = status.get("classification") or record.get(
+        "classification"
+    )
+    # Dead/absent pid plus a parked or settled source is resumable: quota
+    # death, stale_dead, and a plan-approval pause (USER-NEED / !READY /
+    # awaiting_user_confirm) after the worker exited. Only a live process or
+    # an unknown still-running story is refused.
+    if goalflight_dispatch_states.is_attention_state(source_state):
+        return
+    if goalflight_dispatch_states.is_terminal_state(source_state):
+        return
+    if source_classification in {"stale_dead", "worker_dead"}:
+        return
     if status.get("worker_alive") is True or (
         goalflight_ledger.terminal_state_for(source_state, source_reason) == "unknown"
     ):
@@ -4425,6 +4445,7 @@ def _rebuild_codex_resume_home(
     session_id: str,
     *,
     home_owner_dispatch_id: str | None = None,
+    explicit_account: str | None = None,
 ) -> tuple[str, str]:
     """Refresh auth/config in the original home while preserving its rollout."""
     if not expected_home.is_dir():
@@ -4451,7 +4472,7 @@ def _rebuild_codex_resume_home(
     try:
         rebuilt_home, effective_account = resolve_codex_home(
             project_root,
-            None,
+            explicit_account,
             home_owner_dispatch_id or parent_dispatch_id,
         )
         if (
@@ -4485,11 +4506,25 @@ def _rebuild_codex_resume_home(
 def _cmd_resume(argv: list[str]) -> int:
     parser = _TerseArgumentParser(
         prog=f"{Path(sys.argv[0]).name} resume",
-        description="Resume a recorded worker-CLI session as a tracked dispatch.",
-        usage_hint="try resume <dispatch-id> --prompt-file <path>",
+        description=(
+            "Resume a recorded worker-CLI session as a tracked dispatch. "
+            "Reattaches to the existing worktree, prompt, branch, and partial "
+            "artifacts; does not mint a sibling worktree. Continues quota-"
+            "exhausted, dead, stale_dead, and plan-approval pauses. "
+            "Pass --account to continue on a specific surviving seat."
+        ),
+        usage_hint="try resume <dispatch-id> --prompt-file <path> [--account <seat>]",
     )
     parser.add_argument("dispatch_id")
     parser.add_argument("--prompt-file", required=True)
+    parser.add_argument(
+        "--account",
+        help=(
+            "Seat to bill the resumed worker to. Honored as a pin. "
+            "When omitted, default selection skips recently quota-exhausted "
+            "seats until their reset."
+        ),
+    )
     parser.add_argument(
         "--controller-label",
         help="Controller label used to select a kernel-live project lease.",
@@ -4659,20 +4694,31 @@ def _resume_launch_argv(
         replace["--codex-home-owner-dispatch-id"] = source[
             "codex_home_owner_dispatch_id"
         ]
-    else:
-        # Stay on the seat that owns the session files. Codex rebuilds a
-        # per-dispatch home; grok/cursor/claude sessions live in the seat HOME.
+    resume_account = getattr(resume_args, "account", None)
+    if isinstance(resume_account, str) and resume_account.strip():
+        replace["--account"] = resume_account.strip()
+    elif source["engine"] != "codex":
+        # Stay on the seat that owns the session files unless that seat is
+        # recently quota-exhausted. Codex rebuilds a per-dispatch home;
+        # grok/cursor/claude sessions live in the seat HOME.
         account = record.get("effective_account") or record.get("account")
-        if isinstance(account, str) and account and account != "default":
+        if (
+            isinstance(account, str)
+            and account
+            and account != "default"
+            and not _account_quota_blocked(account, engine=source["engine"])
+        ):
             replace["--account"] = account
     argv = _reconstruct_launch_argv(
         base,
         replace=replace,
         inject=inject,
         strip_flags=_replay_strip_flags() + ("--unregistered-forced", "--occupied-worktree-forced"),
-        strip_options=("--tail", "--status-json", "--prompt"),
+        strip_options=("--tail", "--status-json", "--prompt", "--worktree"),
     )
-    if source["engine"] == "codex":
+    if "--account" not in replace:
+        # Drop a recorded pin onto a now-exhausted (or Codex-rotating) seat
+        # so default selection can skip recently exhausted accounts.
         argv = _remove_option_before_worker_remainder(argv, "--account")
     return argv
 
@@ -5486,6 +5532,79 @@ def _account_home(account: str, engine: str) -> Path:
     return Path.home() / ".goal-flight" / "accounts" / account / engine
 
 
+def _configured_account_names(engine: str) -> list[str]:
+    """Serial listing of configured ``accounts/<name>/<engine>`` seats."""
+    root = Path.home() / ".goal-flight" / "accounts"
+    try:
+        children = sorted(
+            (child for child in root.iterdir() if child.is_dir()),
+            key=lambda path: path.name,
+        )
+    except OSError:
+        return []
+    return [child.name for child in children if (child / engine).exists()]
+
+
+def _account_quota_blocked(
+    account: str | None,
+    *,
+    engine: str | None = None,
+    now: float | None = None,
+) -> bool:
+    """True when this seat recently proved quota_exhausted and has not reset."""
+    if not isinstance(account, str):
+        return False
+    seat = account.strip()
+    if not seat or seat == "default":
+        return False
+    current = time.time() if now is None else float(now)
+    cooldown = _effective_account_cooldown(seat)
+    cooldown_ts = _parse_timestamp_s(cooldown) if cooldown else None
+    if cooldown_ts is not None and current < cooldown_ts:
+        return True
+    try:
+        records = goalflight_ledger.read_records()
+    except OSError:
+        return False
+    for record in records:
+        if not isinstance(record, dict):
+            continue
+        billed = record.get("effective_account") or record.get("account")
+        if billed != seat:
+            continue
+        if engine:
+            recorded_engine = goalflight_ledger.infer_engine(
+                record.get("engine") or record.get("agent")
+            )
+            if recorded_engine != engine:
+                continue
+        policy = goalflight_dispatch_states.retry_policy_for_record(
+            record, now=current
+        )
+        if (
+            isinstance(policy, dict)
+            and policy.get("kind") == goalflight_dispatch_states.LIMIT_KIND_EXHAUSTED
+            and policy.get("eligible") is False
+        ):
+            return True
+    return False
+
+
+def _first_unblocked_account(
+    engine: str,
+    *,
+    exclude: set[str] | None = None,
+    now: float | None = None,
+) -> str | None:
+    blocked = exclude or set()
+    for name in _configured_account_names(engine):
+        if name in blocked:
+            continue
+        if not _account_quota_blocked(name, engine=engine, now=now):
+            return name
+    return None
+
+
 def _apply_home_env(env: dict[str, str], home: Path) -> None:
     env["HOME"] = str(home)
     env["XDG_CONFIG_HOME"] = str(home / ".config")
@@ -5544,6 +5663,8 @@ def grok_selected_account(args) -> str | None:
         except BaseException:
             # Selection is an optimisation; never let it fail a dispatch.
             selected = None
+        if selected and _account_quota_blocked(selected, engine="grok"):
+            selected = _first_unblocked_account("grok", exclude={selected})
     args._grok_selected_account = selected
     return selected
 
@@ -5680,33 +5801,61 @@ def _codex_seat_api():
     return _CODEX_SEAT_API_CACHE
 
 
-def resolve_codex_home(
+def _call_resolve_codex_seat(
+    api,
     project_root: Path | str,
     explicit_account: str | None,
     dispatch_id: str,
 ) -> tuple[str | None, str | None]:
-    """Resolve one launch snapshot without ever failing the dispatch."""
-    api = _codex_seat_api()
-    if api is None:
-        return None, None
     try:
         resolved = api.resolve_codex_seat(
             str(project_root),
             explicit_account,
             dispatch_id,
         )
-        if not isinstance(resolved, tuple) or len(resolved) != 2:
-            return None, None
-        home, effective_account = resolved
-        if home is None and effective_account is None:
-            return None, None
-        if not isinstance(home, str) or not home:
-            return None, None
-        if not isinstance(effective_account, str) or not effective_account:
-            return None, None
-        return home, effective_account
     except BaseException:
         return None, None
+    if not isinstance(resolved, tuple) or len(resolved) != 2:
+        return None, None
+    home, effective_account = resolved
+    if home is None and effective_account is None:
+        return None, None
+    if not isinstance(home, str) or not home:
+        return None, None
+    if not isinstance(effective_account, str) or not effective_account:
+        return None, None
+    return home, effective_account
+
+
+def resolve_codex_home(
+    project_root: Path | str,
+    explicit_account: str | None,
+    dispatch_id: str,
+) -> tuple[str | None, str | None]:
+    """Resolve one launch snapshot without ever failing the dispatch.
+
+    An explicit ``--account`` is honored as a pin. Unpinned selection skips
+    recently quota-exhausted seats until their reset rather than dying on
+    the first serial seat.
+    """
+    api = _codex_seat_api()
+    if api is None:
+        return None, None
+    if explicit_account:
+        return _call_resolve_codex_seat(
+            api, project_root, explicit_account, dispatch_id
+        )
+    resolved = _call_resolve_codex_seat(api, project_root, None, dispatch_id)
+    home, account = resolved
+    if account is None or not _account_quota_blocked(account, engine="codex"):
+        return resolved
+    alternative = _first_unblocked_account("codex", exclude={account})
+    if alternative is None:
+        return resolved
+    retried = _call_resolve_codex_seat(
+        api, project_root, alternative, dispatch_id
+    )
+    return retried if retried != (None, None) else resolved
 
 
 def cleanup_codex_dispatch_home(dispatch_id: str) -> None:
@@ -17320,7 +17469,7 @@ def build_worker(args, prompt_path, raw_argv: list[str]):
 # list against the dispatch table so a new subcommand cannot be added silently.
 _SUBCOMMAND_HELP: tuple[tuple[str, str], ...] = (
     ("steer", "append, list, or wait on a live worker's mailbox"),
-    ("resume", "continue a recorded worker session as a tracked dispatch"),
+    ("resume", "continue a recorded worker session in its existing worktree"),
     ("reconcile-abandoned", "dry-run report of abandoned dispatches; drain writes"),
     ("drain", "launch queued dispatch requests"),
     ("dashboard-refresh", "rebuild the dashboard projection"),
@@ -18143,6 +18292,7 @@ def main(argv: list[str] | None = None) -> int:
                             resume_home,
                             args.codex_session_id,
                             home_owner_dispatch_id=codex_home_owner_dispatch_id,
+                            explicit_account=getattr(args, "account", None),
                         )
                     )
             else:

--- a/tests/python/test_codex_resume_dispatch.py
+++ b/tests/python/test_codex_resume_dispatch.py
@@ -1382,3 +1382,386 @@ def test_blocked_capacity_resume_status_preserves_full_lineage(
         assert payload["codex_session_id"] == SESSION_ID
         assert payload["codex_home"] == str(home)
         assert payload["codex_home_owner_dispatch_id"] == parent_id
+
+
+def _option_value(argv: list[str], flag: str) -> str | None:
+    prefix = flag + "="
+    for index, token in enumerate(argv):
+        if token == "--":
+            break
+        if token == flag:
+            if index + 1 >= len(argv):
+                return None
+            return argv[index + 1]
+        if token.startswith(prefix):
+            return token[len(prefix) :]
+    return None
+
+
+def test_resume_reuses_worktree_and_does_not_mint_a_new_seat(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Failing-before / passing-after: resume keeps the parent tree.
+
+    A parent launched with ``--worktree HEAD`` used to reconstruct that flag.
+    The child then acquired a fresh pooled seat, reset it, and abandoned the
+    partial work. Resume must pin the recorded cwd and never call acquire.
+    """
+    parent_id = "wt-resume-parent"
+    worktree = tmp_path / "worktrees" / "wt-1"
+    worktree.mkdir(parents=True)
+    (worktree / "partial.txt").write_text("keep me\n", encoding="utf-8")
+    home = _dispatch_home(tmp_path, parent_id)
+    _write_rollout(home)
+    record = _write_parent_record(tmp_path, dispatch_id=parent_id, home=home)
+    record.update(
+        {
+            "worker_cwd": str(worktree),
+            "state": "quota_exhausted",
+            "terminal_state": "quota_exhausted",
+            "dispatch_argv": [
+                "--agent",
+                "codex",
+                "--shape",
+                "bash",
+                "--dispatch-id",
+                parent_id,
+                "--cwd",
+                str(worktree),
+                "--worktree",
+                "HEAD",
+                "--prompt-file",
+                str(tmp_path / "old.md"),
+            ],
+        }
+    )
+    L.write_record(record)
+    prompt = tmp_path / "revisions.md"
+    prompt.write_text("Continue in the same tree.\n", encoding="utf-8")
+    acquire_calls: list[tuple] = []
+
+    def refuse_acquire(*args, **kwargs):
+        acquire_calls.append((args, kwargs))
+        raise AssertionError("resume must not mint a sibling worktree")
+
+    monkeypatch.setattr(WP, "acquire_worktree_seat", refuse_acquire)
+    captured: list[list[str]] = []
+    monkeypatch.setattr(
+        D,
+        "_reserve_auto_dispatch_id",
+        lambda _agent, _base: "wt-resume-child",
+    )
+    monkeypatch.setattr(
+        D,
+        "main",
+        lambda argv=None: captured.append(list(argv or [])) or 0,
+    )
+
+    assert (
+        D._cmd_resume(
+            [parent_id, "--prompt-file", str(prompt), "--unregistered-forced"]
+        )
+        == 0
+    )
+    launch = captured[0]
+    assert "--worktree" not in launch
+    assert Path(_option_value(launch, "--cwd") or "").resolve() == worktree.resolve()
+    assert acquire_calls == []
+    assert (worktree / "partial.txt").read_text(encoding="utf-8") == "keep me\n"
+
+
+def test_bind_dispatch_worktree_skips_acquire_on_resume(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    calls: list[object] = []
+    monkeypatch.setattr(
+        WP,
+        "acquire_worktree_seat",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+    args = SimpleNamespace(
+        worktree="HEAD",
+        parent_dispatch_id="parent-dispatch",
+        dispatch_id="child-dispatch",
+        cwd=str(tmp_path / "existing-tree"),
+        _worktree_seat=None,
+    )
+    assert D._bind_dispatch_worktree(args) is None
+    assert calls == []
+    assert args.cwd == str(tmp_path / "existing-tree")
+
+
+def test_resume_of_quota_exhausted_dispatch_honors_account(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    parent_id = "quota-parent"
+    home = _dispatch_home(tmp_path, parent_id)
+    _write_rollout(home)
+    record = _write_parent_record(tmp_path, dispatch_id=parent_id, home=home)
+    record.update(
+        {
+            "state": "quota_exhausted",
+            "terminal_state": "quota_exhausted",
+            "effective_account": "cf9f50",
+            "account": "cf9f50",
+            "reason": {
+                "limit_state": "quota_exhausted",
+                "reset_at": "2033-09-07T02:18:00+00:00",
+            },
+        }
+    )
+    L.write_record(record)
+    prompt = tmp_path / "revisions.md"
+    prompt.write_text("Continue after quota death.\n", encoding="utf-8")
+    captured: list[list[str]] = []
+    monkeypatch.setattr(
+        D,
+        "_reserve_auto_dispatch_id",
+        lambda _agent, _base: "quota-resume-child",
+    )
+    monkeypatch.setattr(
+        D,
+        "main",
+        lambda argv=None: captured.append(list(argv or [])) or 0,
+    )
+
+    assert (
+        D._cmd_resume(
+            [
+                parent_id,
+                "--prompt-file",
+                str(prompt),
+                "--unregistered-forced",
+                "--account",
+                "25ca6b",
+            ]
+        )
+        == 0
+    )
+    launch = captured[0]
+    assert _option_value(launch, "--account") == "25ca6b"
+    assert launch[launch.index("--parent-dispatch-id") + 1] == parent_id
+    assert Path(_option_value(launch, "--cwd") or "").resolve() == tmp_path.resolve()
+
+
+def test_resume_of_plan_approval_pause_reuses_worktree(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Plan-approval / !READY pause: resume is the continue, not a sibling tree."""
+    parent_id = "plan-parent"
+    worktree = tmp_path / "worktrees" / "b-3374"
+    worktree.mkdir(parents=True)
+    (worktree / "PLAN.md").write_text("# plan awaiting approval\n", encoding="utf-8")
+    home = _dispatch_home(tmp_path, parent_id)
+    _write_rollout(home)
+    record = _write_parent_record(tmp_path, dispatch_id=parent_id, home=home)
+    record.update(
+        {
+            "worker_cwd": str(worktree),
+            "state": "awaiting_user_confirm",
+            "terminal_state": "unknown",
+            "classification": "stale_dead",
+            "dispatch_argv": [
+                "--agent",
+                "codex",
+                "--cwd",
+                str(worktree),
+                "--worktree",
+                "HEAD",
+                "--prompt-file",
+                str(tmp_path / "plan.md"),
+            ],
+        }
+    )
+    L.write_record(record)
+    prompt = tmp_path / "approve.md"
+    prompt.write_text("Controller approved the PLAN. Continue.\n", encoding="utf-8")
+    captured: list[list[str]] = []
+    monkeypatch.setattr(
+        D,
+        "_reserve_auto_dispatch_id",
+        lambda _agent, _base: "plan-resume-child",
+    )
+    monkeypatch.setattr(
+        D,
+        "main",
+        lambda argv=None: captured.append(list(argv or [])) or 0,
+    )
+
+    assert (
+        D._cmd_resume(
+            [parent_id, "--prompt-file", str(prompt), "--unregistered-forced"]
+        )
+        == 0
+    )
+    launch = captured[0]
+    assert "--worktree" not in launch
+    assert Path(_option_value(launch, "--cwd") or "").resolve() == worktree.resolve()
+    assert (worktree / "PLAN.md").is_file()
+
+
+def test_resume_occupancy_skips_parent_plan_approval_row(
+    tmp_path: Path,
+) -> None:
+    parent_id = "occ-plan-parent"
+    child_id = "occ-plan-child"
+    home = _dispatch_home(tmp_path, parent_id)
+    _write_rollout(home)
+    record = _write_parent_record(tmp_path, dispatch_id=parent_id, home=home)
+    record.update(
+        {
+            "worker_cwd": str(tmp_path),
+            "state": "awaiting_user_confirm",
+            "terminal_state": "unknown",
+            "hostname": __import__("socket").gethostname(),
+        }
+    )
+    L.write_record(record)
+    args = SimpleNamespace(
+        cwd=str(tmp_path),
+        dispatch_id=child_id,
+        parent_dispatch_id=parent_id,
+        read_only=False,
+        os_sandbox=None,
+    )
+    occupied, unknown, occupied_state = D._worktree_incumbent_reason(args)
+    assert occupied is None
+    assert unknown is None
+    assert occupied_state is None
+
+
+def test_resume_rebuild_honors_explicit_account(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    dispatch_id = "explicit-seat-parent"
+    home = _dispatch_home(tmp_path, dispatch_id)
+    rollout = _write_rollout(home)
+    (home / "auth.json").write_text("old-seat", encoding="utf-8")
+    calls: list[tuple[Path, str | None, str]] = []
+
+    def resolve(
+        project_root: Path,
+        explicit_account: str | None,
+        resolved_dispatch_id: str,
+    ) -> tuple[str, str]:
+        calls.append((project_root, explicit_account, resolved_dispatch_id))
+        home.mkdir(parents=True)
+        (home / "auth.json").write_text(str(explicit_account), encoding="utf-8")
+        return str(home), str(explicit_account)
+
+    monkeypatch.setattr(D, "resolve_codex_home", resolve)
+    monkeypatch.setattr(D, "cleanup_codex_dispatch_home", lambda _dispatch_id: None)
+
+    rebuilt, effective_account = D._rebuild_codex_resume_home(
+        tmp_path,
+        dispatch_id,
+        home,
+        SESSION_ID,
+        explicit_account="25ca6b",
+    )
+
+    assert calls == [(tmp_path, "25ca6b", dispatch_id)]
+    assert rebuilt == str(home)
+    assert effective_account == "25ca6b"
+    assert (home / "auth.json").read_text(encoding="utf-8") == "25ca6b"
+    assert S.rollout_path(home, SESSION_ID) == rollout
+
+
+def test_unpinned_codex_selection_skips_recently_exhausted_seat(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    state = Path(os.environ["GOALFLIGHT_CODEX_STATE_DIR"])
+    state.mkdir(parents=True, exist_ok=True)
+    (state / "codex-seat-states.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "seats": {
+                    "4c9435": {"cooldown_until": "2033-09-07T02:18:00+00:00"},
+                    "25ca6b": {},
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    accounts = tmp_path / "home" / ".goal-flight" / "accounts"
+    for name in ("4c9435", "25ca6b"):
+        (accounts / name / "codex").mkdir(parents=True)
+    L.write_record(
+        {
+            "schema": L.SCHEMA,
+            "dispatch_id": "dead-seat-row",
+            "agent": "codex",
+            "engine": "codex",
+            "effective_account": "4c9435",
+            "state": "quota_exhausted",
+            "terminal_state": "quota_exhausted",
+            "reset_at": "2033-09-07T02:18:00+00:00",
+            "started_at": L.utc_now(),
+        }
+    )
+    seen: list[str | None] = []
+
+    def resolve_seat(_project_root, explicit_account, _dispatch_id):
+        seen.append(explicit_account)
+        if explicit_account is None:
+            return str(tmp_path / "home-4c9435"), "4c9435"
+        return str(tmp_path / f"home-{explicit_account}"), explicit_account
+
+    monkeypatch.setattr(
+        D,
+        "_codex_seat_api",
+        lambda: SimpleNamespace(resolve_codex_seat=resolve_seat),
+    )
+
+    home, account = D.resolve_codex_home(tmp_path, None, "fresh-dispatch")
+    assert seen[0] is None
+    assert "25ca6b" in seen
+    assert account == "25ca6b"
+    assert home.endswith("home-25ca6b")
+
+
+def test_explicit_account_is_honored_even_when_not_first(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    seen: list[str | None] = []
+
+    def resolve_seat(_project_root, explicit_account, _dispatch_id):
+        seen.append(explicit_account)
+        return str(tmp_path / "home-d78343"), explicit_account
+
+    monkeypatch.setattr(
+        D,
+        "_codex_seat_api",
+        lambda: SimpleNamespace(resolve_codex_seat=resolve_seat),
+    )
+    home, account = D.resolve_codex_home(tmp_path, "d78343", "pinned-dispatch")
+    assert seen == ["d78343"]
+    assert account == "d78343"
+    assert home.endswith("home-d78343")
+
+
+def test_account_quota_blocked_holds_until_reset(tmp_path: Path) -> None:
+    L.write_record(
+        {
+            "schema": L.SCHEMA,
+            "dispatch_id": "exhausted-row",
+            "agent": "codex",
+            "engine": "codex",
+            "effective_account": "86e5d2",
+            "state": "quota_exhausted",
+            "terminal_state": "quota_exhausted",
+            "reset_at": "2033-09-07T02:18:00+00:00",
+            "started_at": L.utc_now(),
+        }
+    )
+    assert D._account_quota_blocked("86e5d2", engine="codex") is True
+    assert D._account_quota_blocked("25ca6b", engine="codex") is False

--- a/tests/python/test_dispatch_argv_fidelity.py
+++ b/tests/python/test_dispatch_argv_fidelity.py
@@ -574,6 +574,50 @@ def test_resume_binds_worker_cwd_without_dispatch_argv(
     assert _option_value(launch, "--os-sandbox") == "off"
 
 
+def test_resume_strips_worktree_and_keeps_recorded_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Resume must not replay --worktree: that mints a sibling pooled seat."""
+    main, worktree = _make_repo_with_worktree(tmp_path)
+    parent_id = "resume-worktree-parent"
+    recorded = [
+        "--agent",
+        "codex",
+        "--shape",
+        "bash",
+        "--dispatch-id",
+        parent_id,
+        "--cwd",
+        str(worktree),
+        "--worktree",
+        "HEAD",
+        "--prompt-file",
+        str(worktree / "old.md"),
+        "--task",
+        "t-123",
+    ]
+    _write_codex_parent(
+        tmp_path,
+        dispatch_id=parent_id,
+        worktree=worktree,
+        dispatch_argv=recorded,
+        worker_cwd=str(worktree),
+    )
+    prompt = tmp_path / "revisions.md"
+    prompt.write_text("continue.\n", encoding="utf-8")
+    captured = _capture_resume(monkeypatch, "codex-resume-wt-child")
+    assert (
+        D._cmd_resume(
+            [parent_id, "--prompt-file", str(prompt), "--unregistered-forced"]
+        )
+        == 0
+    )
+    launch = captured[0]
+    assert "--worktree" not in launch
+    assert Path(_option_value(launch, "--cwd") or "").resolve() == worktree
+    assert Path(_option_value(launch, "--cwd") or "").resolve() != main
+
+
 def test_every_launch_flag_is_classified() -> None:
     """A new launch-parser flag must be classified, or it will be dropped silently.
 

--- a/tests/python/test_dispatch_registration_gate.py
+++ b/tests/python/test_dispatch_registration_gate.py
@@ -1139,6 +1139,7 @@ def test_help_documents_unregistered_override() -> None:
     assert "--controller-label" in resume_help.stdout
     assert "--controller-pid" in resume_help.stdout
     assert "--controller-session-id" in resume_help.stdout
+    assert "--account" in resume_help.stdout
 
 
 def _stamp_args(**overrides) -> argparse.Namespace:

--- a/tests/python/test_engine_resume_dispatch.py
+++ b/tests/python/test_engine_resume_dispatch.py
@@ -260,6 +260,100 @@ def test_resume_verb_passes_grok_lineage(
     assert "--codex-resume-home" not in launch
 
 
+def test_resume_honors_explicit_grok_account(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    parent_id = "grok-quota-parent"
+    worktree = tmp_path / "b-3363"
+    worktree.mkdir()
+    record = _write_parent(
+        tmp_path,
+        dispatch_id=parent_id,
+        agent="grok-code",
+        engine="grok",
+        session_id=GROK_SESSION,
+        state="quota_exhausted",
+    )
+    record.update(
+        {
+            "worker_cwd": str(worktree),
+            "effective_account": "cf9f50",
+            "account": "cf9f50",
+            "terminal_state": "quota_exhausted",
+            "dispatch_argv": [
+                "--agent",
+                "grok-code",
+                "--cwd",
+                str(worktree),
+                "--worktree",
+                "HEAD",
+                "--account",
+                "cf9f50",
+            ],
+        }
+    )
+    L.write_record(record)
+    prompt = tmp_path / "brief.md"
+    prompt.write_text("continue on a live seat.\n", encoding="utf-8")
+    captured: list[list[str]] = []
+    monkeypatch.setattr(
+        D,
+        "_reserve_auto_dispatch_id",
+        lambda agent, _base: f"{agent}-child",
+    )
+    monkeypatch.setattr(
+        D,
+        "main",
+        lambda argv=None: captured.append(list(argv or [])) or 0,
+    )
+    assert (
+        D._cmd_resume(
+            [
+                parent_id,
+                "--prompt-file",
+                str(prompt),
+                "--unregistered-forced",
+                "--account",
+                "d78343",
+            ]
+        )
+        == 0
+    )
+    launch = captured[0]
+    assert launch[launch.index("--account") + 1] == "d78343"
+    assert "--worktree" not in launch
+    assert Path(launch[launch.index("--cwd") + 1]).resolve() == worktree.resolve()
+
+
+def test_grok_default_selection_skips_recently_exhausted_seat(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    accounts = tmp_path / "home" / ".goal-flight" / "accounts"
+    for name in ("cf9f50", "d78343"):
+        (accounts / name / "grok").mkdir(parents=True)
+    L.write_record(
+        {
+            "schema": L.SCHEMA,
+            "dispatch_id": "grok-dead-seat",
+            "agent": "grok-code",
+            "engine": "grok",
+            "effective_account": "cf9f50",
+            "state": "quota_exhausted",
+            "terminal_state": "quota_exhausted",
+            "reset_at": "2033-09-07T02:18:00+00:00",
+            "started_at": L.utc_now(),
+        }
+    )
+    monkeypatch.setattr(
+        "grok_seats.select_seat",
+        lambda **_kwargs: "cf9f50",
+    )
+    args = _grok_args(account=None)
+    assert D.grok_selected_account(args) == "d78343"
+
+
 def test_resume_refuses_live_grok_source(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Live controllers (2026-09-01) could not `resume` a dead or quota-exhausted worker into its existing worktree. Codex seats such as `cf9f50` / `4c9435` / `86e5d2` hit usage limits; default serial seat order still started at those dead seats, so a plain dispatch died immediately. Operators wanted to continue partial work in trees already holding artifacts (b-3374, b-3363, …) rather than redispatch from scratch. They reported resume as broken and launched **fresh** workers into those trees with `--account` forced onto surviving seats (`25ca6b` / `d78343`).

A second supported continue is a worker that paused after a PLAN / `!READY` / USER-NEED approval gate. Resume must be that continue, not a sibling dispatch.

## What changed

`goalflight_dispatch.py resume` (existing verb; no parallel path):

1. **Same worktree.** Resume no longer replays `--worktree`. That flag was acquiring a new pooled seat, resetting it, and abandoning partial work. Resume now pins the recorded `worker_cwd` and skips seat acquire when `parent_dispatch_id` is set.
2. **Resumable sources.** `quota_exhausted`, dead pid, `stale_dead`, and plan-approval pauses (`awaiting_user_confirm` / USER-NEED / `!READY` after the worker exited) are continuable. Occupancy skips the parent row so the child can re-enter the same tree.
3. **`--account` honored.** `resume --account <seat>` is a pin, including Codex home rebuild. Default selection skips recently quota-exhausted accounts until their reset instead of dying on the first serial seat.

`python3 scripts/goalflight_dispatch.py --help` lists `resume` as continuing a recorded session in its existing worktree. `resume --help` documents `--account`.

## Tests

Hermetic coverage under the existing dispatch test modules:

- `test_resume_reuses_worktree_and_does_not_mint_a_new_seat` — failing-before / passing-after: parent `--worktree` is stripped, cwd is unchanged, `acquire_worktree_seat` is not called, partial file remains.
- Resume of `quota_exhausted` onto `--account 25ca6b`.
- Resume of a plan-approval pause (`awaiting_user_confirm` + PLAN artifact) reuses the same tree.
- Occupancy skips the parent attention row.
- Unpinned Codex selection skips an exhausted seat when a healthy one exists; explicit `--account` is honored.

## Out of scope

No SKILL.md / `commands/resume.md` / Grok Bot host-wrapper resume changes. No battery-tool-v2 edits, no stolen battery-* leases, no Grok Bot-only fork. Portable dispatch only.

## Reviewer check

`python3 scripts/goalflight_dispatch.py --help` and `resume --help`. The worktree-identity test is the before/after pin: resume keeps the recorded tree and does not mint a sibling.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a445de69-68ad-4182-abd1-beb6b1ce7c7d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a445de69-68ad-4182-abd1-beb6b1ce7c7d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

