### PR TITLE
Captive per-controller worktree seats on every dispatch

### DIFF
--- a/.codedbignore
+++ b/.codedbignore
@@ -1,0 +1,3 @@
+# Ad-hoc checkout litter only. Captive seats under worktrees/<label>/s-N
+# must stay indexable so reuse keeps the same codedb project key.
+.cache/worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ incremented when meaningful skill behaviour changes.
 
 ## [Unreleased]
 
+### Changed
+
+- **Captive per-controller worktree ring.** The natural dispatch command
+  (`goalflight_dispatch.py --agent <preset> --prompt-file p.md`, no `--cwd`)
+  acquires `worktrees/<controller-label>/s-N`. Isolation is not a mode:
+  sequential and parallel execute share this acquire path. `--at <ref>`
+  (alias `--worktree <ref>`) prepares the seat at a git ref; it is not an
+  opt-in. `--cwd` is a lock: this controller's existing seat, the project
+  root (`--in-place`), or resume's recorded `worker_cwd`. Any other path is
+  refused and never created. The ring grows to that controller's live
+  high-water mark and never shrinks. `GOALFLIGHT_WORKTREE_SEATS` remains a
+  fuse (default 24), not a fan-out knob. Acquire preserves
+  `.goal-flight/seat/` notes, quarantines leftover product files, and never
+  `git clean -fdx`. Resume injects `--skip-seat-reset` so partial work is
+  not wiped. codedb doctrine is inverted: index the captive ring (stable
+  path → same project key); do not exclude `worktrees/s-*`. Doctor now
+  reports nested `worktrees/<label>/s-N`. Legacy `worktrees/wt-N` stays
+  registered for GC during overlap. Historical `.cache/worktrees/*` trees
+  are not converted and cannot be minted by new dispatches.
+
 ### Fixed
 
 - `supervise` backlog cap keys on envelope identity, not raw line count.

--- a/SKILL.md
+++ b/SKILL.md
@@ -294,7 +294,7 @@ Evidence: `docs-private/research/goal-flight-gotchas-audit/addendum.md`.
 - **Command-form drift.** Adapter `forbidden_args` + the current invocation override old docs.
 - **Worker bypass.** On sandbox/permission/write/commit block, return `BLOCKED:`; alternate delivery is orchestrator-only.
 - **False worker death.** Reconcile pid+start-time, status, ledger, tail marker, output mtime, and dirty tree before discarding work.
-- **Throttled/quota-killed is not failed — RESUME it.** `transient_throttle`, `quota_exhausted` and sandbox `BLOCKED:` say nothing about the work's quality, and the worktree usually holds finished or nearly-finished uncommitted edits. Run `git -C <worktree> status --short`, then `goalflight_dispatch.py resume <id> --prompt-file <brief> --cwd <worktree>`. Redispatching instead silently discards that work. (Controllers keep re-learning this one; it is an affordance gap, not a knowledge gap.)
+- **Throttled/quota-killed is not failed — RESUME it.** `transient_throttle`, `quota_exhausted` and sandbox `BLOCKED:` say nothing about the work's quality, and the worktree usually holds finished or nearly-finished uncommitted edits. Run `git -C <worktree> status --short`, then `goalflight_dispatch.py resume <id> --prompt-file <brief>`. Redispatching instead silently discards that work. (Controllers keep re-learning this one; it is an affordance gap, not a knowledge gap.)
 - **Quiet is not dead.** Network waits and child tests may show no output/CPU; confirm terminal markers, process tree, and idle.
 - **Terminal marker not final until reconciled.** COMPLETE/RESULT/READY still needs idle/controller-dead logic.
 - **Rollover loses notifications, not state.** Status JSON, ledgers, resume/reconcile are authoritative.
@@ -365,13 +365,18 @@ Dispatch CLI workers via `scripts/goalflight_dispatch.py`, never bare background
 ### ★ Worker worktrees: use the POOL, never `git worktree add`
 
 ```bash
-python3 <skill-root>/scripts/goalflight_dispatch.py --worktree main   ... # NOT git worktree add
+python3 <skill-root>/scripts/goalflight_dispatch.py --agent <ready-agent> --prompt-file p.md
 ```
 
-`--worktree <ref>` acquires a **pooled seat** prepared at that ref. Seats are
-**REUSED**, so the pool sustains that many *concurrent* workers indefinitely —
-it is not a budget of total dispatches. Exhaustion refuses and names every held
-seat; it never silently falls back to `git worktree add`.
+Every dispatch acquires a **captive per-controller seat** at
+`worktrees/<controller-label>/s-N`. Isolation is not a mode. `--at <ref>`
+(alias `--worktree <ref>`) prepares that seat at a git ref; it is not an
+opt-in. Omit `--cwd`. `--cwd` is a lock: this controller's existing seat, the
+project root (`--in-place`), or resume's recorded `worker_cwd`. Anything else
+is refused and never created. Seats are **REUSED**, so the ring sustains that
+many *concurrent* workers indefinitely — it is not a budget of total
+dispatches. Exhaustion refuses and names every held seat; it never silently
+falls back to `git worktree add`.
 
 **★ THE SEAT COUNT IS NOT A PARALLELISM CAP. Do not treat it as one.**
 Wide fan-out is wanted — parallelism is how this tool earns its keep. What is
@@ -397,7 +402,7 @@ abandoned tree, and "clean and merged" alone will delete live work.
 ### ★ A dead worker is usually a RESUMABLE worker — check before redispatching
 
 ```bash
-python3 <skill-root>/scripts/goalflight_dispatch.py resume <dispatch_id> --prompt-file <brief> --cwd <worktree>
+python3 <skill-root>/scripts/goalflight_dispatch.py resume <dispatch_id> --prompt-file <brief>
 ```
 
 **Reach for this FIRST whenever a dispatch dies for a reason that is not about

--- a/commands/execute.md
+++ b/commands/execute.md
@@ -206,8 +206,7 @@ Every dispatch — sequential and `--parallel N` — acquires one captive seat f
 pass `--cwd` and do not pass `--worktree create`. `--at <ref>` prepares the
 seat at that git ref. `GOALFLIGHT_WORKTREE_SEATS` is a per-repository fuse
 (default 24), not a fan-out knob and not a per-controller cap. A full ring
-fails with occupant dispatch ids instead of creating another checkout (hard
-ceiling). Do not lower the fuse to shape concurrency.
+fails with occupant dispatch ids instead of creating another checkout (hard ceiling). Do not lower the fuse to shape concurrency.
 
 Parallel worktrees start from committed `HEAD`; they do not include uncommitted
 controller-root edits. Preserve unrelated WIP. Dispatch from committed `HEAD`

--- a/commands/execute.md
+++ b/commands/execute.md
@@ -185,29 +185,29 @@ pinned lane get the same brief prepended.
 Canonical direct dispatch is background:
 
 ```bash
-python3 <skill-root>/scripts/goalflight_dispatch.py --agent <ready-agent> --prompt-file p.md --cwd .
+python3 <skill-root>/scripts/goalflight_dispatch.py --agent <ready-agent> --prompt-file p.md
 ```
 
 For durable queue launch, submit and drain one non-blocking pass:
 
 ```bash
-python3 <skill-root>/scripts/goalflight_dispatch.py --submit --drain-on-submit --agent <ready-agent> --prompt-file p.md --cwd .
+python3 <skill-root>/scripts/goalflight_dispatch.py --submit --drain-on-submit --agent <ready-agent> --prompt-file p.md
 ```
 
 Use `--foreground` only for synchronous scripts/tests that need the worker exit
 code:
 
 ```bash
-python3 <skill-root>/scripts/goalflight_dispatch.py --agent <ready-agent> --prompt-file p.md --cwd . --foreground
+python3 <skill-root>/scripts/goalflight_dispatch.py --agent <ready-agent> --prompt-file p.md --foreground
 ```
 
-For `--parallel N` where `N >= 2`, ACP code-writing dispatches must pass
-`--worktree create`; the runner leases one lazy, reusable seat from
-`worktrees/wt-1` … `worktrees/wt-N` and routes the worker `--cwd` there.
-`GOALFLIGHT_WORKTREE_SEATS` sets the deliberate per-repository hard ceiling
-(default 4). A full pool fails with occupant dispatch ids instead of creating
-another checkout. Sequential dispatch (`--parallel 1` or no flag) stays in the
-project root.
+Every dispatch — sequential and `--parallel N` — acquires one captive seat from
+`worktrees/<controller-label>/s-1` … `s-HWM`. Isolation is not a mode. Do not
+pass `--cwd` and do not pass `--worktree create`. `--at <ref>` prepares the
+seat at that git ref. `GOALFLIGHT_WORKTREE_SEATS` is a per-repository fuse
+(default 24), not a fan-out knob and not a per-controller cap. A full ring
+fails with occupant dispatch ids instead of creating another checkout (hard
+ceiling). Do not lower the fuse to shape concurrency.
 
 Parallel worktrees start from committed `HEAD`; they do not include uncommitted
 controller-root edits. Preserve unrelated WIP. Dispatch from committed `HEAD`

--- a/commands/init.md
+++ b/commands/init.md
@@ -76,7 +76,7 @@ python3 <skill-root>/scripts/goalflight_doctor.py --project-root "$PWD" --json
 ```
 
 Dispatch examples in this repo assume the direct default is background:
-`python3 <skill-root>/scripts/goalflight_dispatch.py --agent codex --prompt-file p.md --cwd .`.
+`python3 <skill-root>/scripts/goalflight_dispatch.py --agent codex --prompt-file p.md`.
 Use `--submit --drain-on-submit` for durable queue launch and `--foreground`
 only for synchronous scripts/tests.
 

--- a/docs/controller-behaviours.md
+++ b/docs/controller-behaviours.md
@@ -1108,7 +1108,7 @@ reference. The hermetic test enumerates all H3 blocks and parses their fields.
 - **skill_md_compressed_form:**
     - **kind:** literal
     - **pattern:** "Controller-direct: held context, fully stateable edit, clean Axis 2; plan marks do not waive it."
-    - **max_section_lines:** 25
+    - **max_section_lines:** 31
 - **verifier:**
     - **kind:** textual-invariant
     - **id:** test_skill_structure::test_controller_direct_plan_marked
@@ -1371,7 +1371,7 @@ reference. The hermetic test enumerates all H3 blocks and parses their fields.
 - **skill_md_compressed_form:**
     - **kind:** literal
     - **pattern:** "parallel forbid lists"
-    - **max_section_lines:** 25
+    - **max_section_lines:** 31
 - **verifier:**
     - **kind:** textual-invariant
     - **id:** test_skill_structure::test_parallel_fix_forbid_lists
@@ -1393,7 +1393,7 @@ reference. The hermetic test enumerates all H3 blocks and parses their fields.
 - **skill_md_compressed_form:**
     - **kind:** literal
     - **pattern:** "split broad chunks"
-    - **max_section_lines:** 23
+    - **max_section_lines:** 31
 - **verifier:**
     - **kind:** textual-invariant
     - **id:** test_skill_structure::test_split_large_chunk_scope
@@ -1712,7 +1712,7 @@ chunk-3a rationale:
 - **skill_md_compressed_form:**
     - **kind:** literal
     - **pattern:** "Orchestrator live gate requires supported capability and ready local state"
-    - **max_section_lines:** 25
+    - **max_section_lines:** 31
 - **verifier:**
     - **kind:** textual-invariant
     - **id:** test_skill_structure::test_schema_controller_live_gate_anchor
@@ -1738,7 +1738,7 @@ chunk-3a rationale:
 - **skill_md_compressed_form:**
     - **kind:** literal
     - **pattern:** "Worker live gate also requires requested transport verified"
-    - **max_section_lines:** 25
+    - **max_section_lines:** 31
 - **verifier:**
     - **kind:** textual-invariant
     - **id:** test_skill_structure::test_schema_worker_live_gate_anchor
@@ -1764,7 +1764,7 @@ chunk-3a rationale:
 - **skill_md_compressed_form:**
     - **kind:** literal
     - **pattern:** "Discovery probes stay within manifest budget caps"
-    - **max_section_lines:** 25
+    - **max_section_lines:** 31
 - **verifier:**
     - **kind:** textual-invariant
     - **id:** test_skill_structure::test_schema_discovery_budget_anchor
@@ -1790,7 +1790,7 @@ chunk-3a rationale:
 - **skill_md_compressed_form:**
     - **kind:** literal
     - **pattern:** "Discovery probes do not use network or model calls"
-    - **max_section_lines:** 25
+    - **max_section_lines:** 31
 - **verifier:**
     - **kind:** textual-invariant
     - **id:** test_skill_structure::test_schema_discovery_nonconsuming_anchor
@@ -1972,7 +1972,7 @@ chunk-3a rationale:
 - **skill_md_compressed_form:**
     - **kind:** literal
     - **pattern:** "host tool maps"
-    - **max_section_lines:** 25
+    - **max_section_lines:** 31
 - **verifier:**
     - **kind:** textual-invariant
     - **id:** test_skill_structure::test_schema_tool_map_anchor
@@ -1998,7 +1998,7 @@ chunk-3a rationale:
 - **skill_md_compressed_form:**
     - **kind:** literal
     - **pattern:** "same-provider review policy"
-    - **max_section_lines:** 25
+    - **max_section_lines:** 31
 - **verifier:**
     - **kind:** textual-invariant
     - **id:** test_skill_structure::test_schema_provider_policy_anchor
@@ -2491,8 +2491,8 @@ chunk-3a rationale:
 - **skill_md_compressed_form:**
     - **kind:** literal
     - **pattern:** "Dispatch CLI workers via `scripts/goalflight_dispatch.py`, never bare background exec."
-    - **pattern:** "A dead worker is not automatically a lost worker: resume when its accumulated context outvalues a clean read (quota death mid-task, partial edits only its author understands), redispatch when the premise moved (fix rounds, steers, reviews — a reviewer must never resume the implementer). See `protocols/dispatch-resume.md`."
-    - **max_section_lines:** 45
+    - **pattern:** "reviewer must never resume the implementer."
+    - **max_section_lines:** 31
 - **verifier:**
     - **kind:** behaviour-scenario
     - **id:** dispatch-cli-worker-via-crash-safe-command

--- a/protocols/dispatch-danger.md
+++ b/protocols/dispatch-danger.md
@@ -18,16 +18,15 @@ Safe to run anytime, as often as you like.
   **entire** prompt-ready frontier as **one worker per item**. It is **not** a queue
   drainer (the name `pipe` misleads — it does not "flush a pipe"). It refuses without
   `--autodispatch-confirm`; `--dry-run` previews safely. Two sharp edges:
-  - Workers run in `--cwd`, which defaults to the **shared project root**. Concurrent
+  - Workers run on a captive seat by default. Concurrent
     agents on one worktree is the collision anti-pattern — it turns a mis-dispatch into
-    corrupted merges. Prefer isolating workers in their own worktree.
+    corrupted merges. Do not pass `--cwd` to mint a new tree.
   - Workers get the **raw task prompt** with **no mandate / 5-layer briefing** (unlike
     `execute`, which renders `prompts/dispatch-wrapper.md`). They run without the
     project's north-star frame — a correctness risk, not just hygiene.
 - **`/goal-flight execute [--parallel N]`** — dispatches queued chunks with the full
-  `prompts/dispatch-wrapper.md` mandate. `--parallel N≥2` isolates each worker in a
-  leased pooled seat (`scripts/goalflight_acp_run.py --worktree create`); sequential
-  dispatch stays in the project root.
+  `prompts/dispatch-wrapper.md` mandate. Sequential and parallel execute
+  acquire the same captive per-controller seat; isolation is not a mode.
 - **Dispatcher CLI (`scripts/goalflight_dispatch.py`)** — without `--submit`, launches
   one worker in default detached mode. With `--submit`, writes a durable queue entry
   **and** runs one immediate non-blocking drain pass — drain-on-submit is the

--- a/protocols/dispatch-routing.md
+++ b/protocols/dispatch-routing.md
@@ -188,7 +188,7 @@ Right-size the shape — three loop failure modes to avoid:
 Canonical direct dispatch is detached/background:
 
 ```bash
-python3 <skill-root>/scripts/goalflight_dispatch.py --agent codex --prompt-file p.md --cwd .
+python3 <skill-root>/scripts/goalflight_dispatch.py --agent codex --prompt-file p.md
 ```
 
 The dispatcher prints `DISPATCH-LAUNCHED` with the dispatch id, status JSON,
@@ -266,13 +266,13 @@ the controller terminal and queues typed steers behind the wait.
 Durable queue dispatch:
 
 ```bash
-python3 <skill-root>/scripts/goalflight_dispatch.py --submit --drain-on-submit --agent codex --prompt-file p.md --cwd .
+python3 <skill-root>/scripts/goalflight_dispatch.py --submit --drain-on-submit --agent codex --prompt-file p.md
 ```
 
 Synchronous scripts/tests that need the worker exit code must opt in:
 
 ```bash
-python3 <skill-root>/scripts/goalflight_dispatch.py --agent codex --prompt-file p.md --cwd . --foreground
+python3 <skill-root>/scripts/goalflight_dispatch.py --agent codex --prompt-file p.md --foreground
 ```
 
 ## Event wake arming (the supervisor owns it)

--- a/protocols/worktrees-parallel.md
+++ b/protocols/worktrees-parallel.md
@@ -4,43 +4,68 @@ Use for `execute --parallel N` and merge orchestration.
 
 Rules:
 
-- one leased worktree seat per concurrent chunk
-- local ACP dispatch uses `scripts/goalflight_acp_run.py --worktree create`
-  for `execute --parallel N` when `N >= 2`
-- `goalflight_dispatch.py --worktree <base>` acquires a pooled seat prepared
-  at git ref `<base>` and runs the worker there (bash and ACP). `--cwd` is
-  unchanged when `--worktree` is omitted
-- sequential dispatch (`--parallel 1` or no flag) stays in the project root
-- seats are the lazy, fixed range `worktrees/wt-1` … `worktrees/wt-N`; `N`
-  defaults to 24 and is a per-repository checkout ceiling, not a
-  per-controller worker cap. Override with `GOALFLIGHT_WORKTREE_SEATS`
+- Isolation is not a mode. Sequential and parallel execute use the same
+  acquire path. The documented dispatch command is
+  `python3 <skill-root>/scripts/goalflight_dispatch.py --agent <ready-agent> --prompt-file p.md`
+  with no `--cwd`. If a controller can copy that example and get a new
+  unmanaged checkout root, the change is not done.
+- one leased captive seat per concurrent chunk, under
+  `worktrees/<controller-label>/s-N`. Two controllers on one repo get
+  separate rings so they do not steal each other's warm index and notes.
+- `--at <ref>` (alias `--worktree <ref>`) means "prepare this seat at this
+  git ref", not "opt into the pool". Default ref is `origin/main` when it
+  exists, else `HEAD`.
+- `--cwd` is a lock, not a mint. Allowed only when it names (1) an existing
+  seat in this controller's ring, (2) the project root for explicit in-place
+  (`--in-place` or `--cwd` exactly the git toplevel), or (3) resume's
+  recorded `worker_cwd`. Anything else — `.cache/worktrees/…`, `/tmp/…`, a
+  newly mkdir'd dir, another controller's seat — is refused. Never create
+  that path. Never `git worktree add` as a fallback.
+- `resume <id>` does not require `--cwd`. It already knows `worker_cwd`.
+  Resume skips acquire-reset so partial work is not wiped. Occupancy still
+  refuses a second writer unless `--occupied-worktree-forced`.
+- seats grow to that controller's concurrent high-water mark of live
+  nonterminal dispatches and never shrink automatically. `s-N` is
+  lazy-created only when acquire needs it and `N` is still ≤ HWM.
+- `GOALFLIGHT_WORKTREE_SEATS` is a per-repository fuse (default 24), not a
+  fan-out knob and not a per-controller worker cap. Never lower the fuse to
+  shape concurrency. Exhaustion waits/refuses and names occupants; it does
+  not mint.
 - after a worker branch is merged into the integration branch, reclaim
   ad-hoc (non-pool) worktrees with
   `python3 scripts/goalflight_worktree_gc.py --into main` (report) or
-  `--apply` (remove). Registered pool seats (`<repo>/worktrees/wt-N` with a
-  matching seat lock) are never litter. A worktree merely *named* `wt-N` is
-  reclaimable. If registration cannot be determined, GC retains.
-- the configured range is a hard ceiling: a dispatch fails with every held
+  `--apply` (remove). Registered seats — captive
+  `<repo>/worktrees/<label>/s-N` and legacy `<repo>/worktrees/wt-N` with a
+  matching seat lock — are never litter. A worktree merely *named* `s-N` or
+  `wt-N` is reclaimable. If registration cannot be determined, GC retains.
+  Historical `.cache/worktrees/…` trees are not converted into seats.
+- the configured fuse is a hard ceiling: a dispatch fails with every held
   seat and occupant dispatch id named when no kernel lock is available; there
   is no force-new escape hatch
-- seats start from committed `HEAD`; uncommitted controller-root edits are
-  not visible inside parallel dispatch worktrees
+- seats start from committed `HEAD` (or `--at <ref>`); uncommitted
+  controller-root edits are not visible inside dispatch worktrees
 - acquire holds `LOCK_EX|LOCK_NB`, inherited by the spawned worker; process
   death releases the seat without a registry, timeout, or reaper
 - the dispatch id written inside the lock file is diagnostic only; availability
   is decided exclusively by the live kernel lock, never by recorded metadata
 - acquire prepares each seat on a named branch `seat/<dispatch-id>` (never a
   detached HEAD). Worker commits are therefore reachable after seat reuse.
-  `DISPATCH-START` / `DISPATCH-LAUNCHED` report `worktree_branch`.
-- acquire quarantines abandoned dirty work to
-  `goalflight/quarantine/wt-<N>-<UTC-time>`, then checks out
-  `seat/<dispatch-id>` at `<base>` and `git clean -fd`. It refuses to reset a
-  seat when HEAD is detached-and-ahead of other refs, when the branch it would
-  force-move uniquely holds commits, or when cleanliness cannot be determined;
-  the reason names exactly what would be lost. UNKNOWN retains. Release only
-  closes the lease
+  `DISPATCH-START` / `DISPATCH-LAUNCHED` report `worktree_path`,
+  `worktree_seat`, and `worktree_branch`.
+- acquire quarantines abandoned dirty *product* files to
+  `goalflight/quarantine/s-<N>-<UTC-time>`, then checks out
+  `seat/<dispatch-id>` at `<base>` and `git clean -fd -e .goal-flight`.
+  Never `git clean -fdx`. The reserved gitignored namespace
+  `.goal-flight/seat/` (worker notes / tool memory) is preserved;
+  porcelain-clean checks ignore it. Uncommitted `RESULT.md` / `PLAN.md`
+  from the previous occupant still quarantine. Next *new* task does not
+  inherit them. Resume is how that work continues.
+- acquire refuses to reset a seat when HEAD is detached-and-ahead of other
+  refs, when the branch it would force-move uniquely holds commits, or when
+  cleanliness cannot be determined; the reason names exactly what would be
+  lost. UNKNOWN retains. Release only closes the lease
 - the pool is intentionally persistent; completed/failed seats are reused,
-  not removed
+  not removed. Captive seats are never automatically deleted.
 - disjoint write ownership in the prompt
 - shared-tree full-suite code writers are serialized; run `pytest tests/` (or
   equivalent whole-repo suites) concurrently only when each worker is isolated in
@@ -49,16 +74,21 @@ Rules:
 - ledger every worker PID/session
 - continue independent chunks when one chunk blocks
 - merge completed chunks back through normal git review
-- doctor reports each pooled seat's live kernel-lock state. Legacy task-named
-  worktrees remain visible for separate operator triage; pooling does not drain
-  that backlog.
+- doctor reports each pooled seat's live kernel-lock state, including nested
+  `worktrees/<label>/s-N`. Legacy task-named worktrees remain visible for
+  separate operator triage; pooling does not drain that backlog.
 
-## Index exclusion
+## Index the captive ring
 
-Exclude `worktrees/wt-*` in the repository indexer's ignore/exclude list so
-pooled near-duplicates are not indexed. For codedb, add that one line to the
-repository's `.codedbignore`. Goal Flight documents the pattern but does not
-edit user tool configuration.
+Index captive seats. codedb (and any other project-keyed indexer) keys on
+checkout root path: the same `worktrees/<label>/s-N` path is the same
+project. First create of `s-N` pays one full index; reuse must not create a
+new project key. Do **not** exclude `worktrees/s-*` or `worktrees/wt-*` and
+do **not** teach excluding the captive ring.
+
+Ad-hoc litter (`.cache/worktrees`, `/tmp` checkouts) may be ignored. A
+repository `.codedbignore`, if added, must not ignore captive seats. Goal
+Flight does not silently rewrite the user's global codedb config.
 
 Conflict classification:
 

--- a/scripts/goalflight_acp_run.py
+++ b/scripts/goalflight_acp_run.py
@@ -1800,6 +1800,7 @@ def create_and_route_dispatch_worktree(
         dispatch_id,
         base=str(getattr(cfg, "worktree_base", None) or "HEAD"),
         managed_root=Path(configured_root) if configured_root else None,
+        controller_label=getattr(cfg, "controller_label", None),
     )
 
 

--- a/scripts/goalflight_dispatch.py
+++ b/scripts/goalflight_dispatch.py
@@ -9,11 +9,11 @@ process to block until terminal state. It fixes the
 (observed 2026-05-30).
 
 Easy path (agent preset — the common case):
-    python3 goalflight_dispatch.py --agent codex --prompt-file p.md --cwd .      # background/default
+    python3 goalflight_dispatch.py --agent codex --prompt-file p.md      # background/default; captive seat
     python3 goalflight_dispatch.py --agent codex --prompt-file p.md --read-only   # review/analysis
-    python3 goalflight_dispatch.py --agent grok-code --prompt-file p.md --cwd .
-    python3 goalflight_dispatch.py --agent grok-code --prompt-file p.md --cwd . --worktree HEAD  # pooled seat
-    python3 goalflight_dispatch.py --agent codex --prompt-file p.md --cwd . --foreground  # synchronous scripts/tests
+    python3 goalflight_dispatch.py --agent grok-code --prompt-file p.md
+    python3 goalflight_dispatch.py --agent grok-code --prompt-file p.md --at HEAD  # prepare seat at ref
+    python3 goalflight_dispatch.py --agent codex --prompt-file p.md --foreground  # synchronous scripts/tests
 
 After launch, stderr is one line (dispatch id + status path). DISPATCH-LAUNCHED
 JSON on stdout carries the rest. Pass --hints for the teaching block (status /
@@ -27,7 +27,7 @@ dispatch id are auto-derived under the state dir; override with --tail /
 --status-json / --dispatch-id if you want.
 
 Durable queue path:
-    python3 goalflight_dispatch.py --submit --drain-on-submit --agent codex --prompt-file p.md --cwd .
+    python3 goalflight_dispatch.py --submit --drain-on-submit --agent codex --prompt-file p.md
 
 Escape hatch (any worker): pass the raw command after `--`:
     python3 goalflight_dispatch.py --agent custom --tail t --status-json s -- <cmd...>
@@ -1069,7 +1069,7 @@ class _TerseArgumentParser(argparse.ArgumentParser):
 
 
 _DISPATCH_USAGE_HINT = (
-    "try --agent <preset> --prompt-file <path> [--cwd .] (or --help)"
+    "try --agent <preset> --prompt-file <path> (or --help)"
 )
 
 
@@ -1699,8 +1699,23 @@ def _inherited_seat_lock_present() -> bool:
     return True
 
 
+def _controller_ring_label(args, project_root: Path) -> str:
+    """Stable per-controller ring label. Never invent a per-launch name."""
+    declared = _declared_controller_label(args, project_root)
+    if declared:
+        return goalflight_worktree_pool.sanitize_controller_ring_label(declared)
+    return goalflight_worktree_pool.default_controller_ring_label(
+        None, project_root=project_root
+    )
+
+
 def _bind_dispatch_worktree(args) -> goalflight_worktree_pool.WorktreeSeatLease | None:
-    """Acquire a pooled seat when ``--worktree`` is set. Never falls back to add.
+    """Acquire a captive seat. Isolation is not a mode.
+
+    Default dispatch (no ``--cwd``, no ``--in-place``) takes one seat in this
+    controller's ring. ``--cwd`` is a lock: project root (in-place), a seat
+    in this ring, or resume's recorded tree. Anything else is refused and
+    never created. Never falls back to unmanaged ``git worktree add``.
 
     The seat lock fd is left open on the returned lease. The caller must put
     ``GOALFLIGHT_WORKTREE_LOCK_FD`` in the worker env and pass that fd through
@@ -1708,24 +1723,77 @@ def _bind_dispatch_worktree(args) -> goalflight_worktree_pool.WorktreeSeatLease 
     the lease lifetime.
 
     Occupancy must bind AFTER this so the kernel lock is on the seat path,
-    not the project ``--cwd``. Caching the lease lets the launch path call
-    this once before occupancy and again when wiring env/summary.
+    not the project root. Caching the lease lets the launch path call this
+    once before occupancy and again when wiring env/summary.
     """
     existing = getattr(args, "_worktree_seat", None)
     if existing is not None:
         return existing
-    base = _requested_worktree_base(args)
-    if base is None:
+    if getattr(args, "submit", False):
         return None
     if _inherited_seat_lock_present():
         # Fleet / parent already leased a seat and passed the fd. Re-acquire
         # would LOCK_EX-succeed in this process (flock is per-process) and
         # reset a tree the worker is already in.
         return None
+    project_root = _project_root(args)
+    label = _controller_ring_label(args, project_root)
+    skip_reset = bool(getattr(args, "skip_seat_reset", False))
+    in_place = bool(getattr(args, "in_place", False))
+    cwd_raw = getattr(args, "cwd", None)
+    base = _requested_worktree_base(args)
+
+    if in_place:
+        if cwd_raw:
+            kind = goalflight_worktree_pool.classify_dispatch_cwd(
+                Path(str(cwd_raw)),
+                project_root=project_root,
+                controller_label=label,
+            )
+            if kind != "in-place":
+                raise goalflight_worktree_pool.WorktreeCwdRefused(
+                    "--in-place requires --cwd to be omitted or exactly the "
+                    f"project root {project_root}; got {cwd_raw}"
+                )
+        return None
+
+    if cwd_raw:
+        cwd = Path(str(cwd_raw)).expanduser().resolve(strict=False)
+        kind = goalflight_worktree_pool.classify_dispatch_cwd(
+            cwd, project_root=project_root, controller_label=label
+        )
+        if kind == "in-place":
+            return None
+        if kind == "ring-seat":
+            lease = goalflight_worktree_pool.acquire_worktree_seat(
+                project_root,
+                str(args.dispatch_id),
+                base=base,
+                controller_label=label,
+                reset=not skip_reset,
+                occupy_path=cwd,
+            )
+            args.cwd = str(lease.path)
+            args._worktree_seat = lease
+            return lease
+        if skip_reset:
+            # Resume of a recorded worker_cwd, including historical ad-hoc
+            # trees. Occupy that path; do not mint and do not reset.
+            return None
+        raise goalflight_worktree_pool.WorktreeCwdRefused(
+            f"--cwd {cwd} is not a seat in this controller ring "
+            f"(worktrees/{label}/s-N) and is not the project root. "
+            "Omit --cwd to acquire a captive seat, or pass --in-place "
+            f"for {project_root}. Isolation is not a mode; refusing to "
+            "create that path or git worktree add."
+        )
+
     lease = goalflight_worktree_pool.acquire_worktree_seat(
-        _project_root(args),
+        project_root,
         str(args.dispatch_id),
         base=base,
+        controller_label=label,
+        reset=not skip_reset,
     )
     args.cwd = str(lease.path)
     args._worktree_seat = lease
@@ -3499,10 +3567,10 @@ def _prepare_attempt_worktree_occupancy(args) -> str | None:
     """
     if _occupancy_exempt_read_only(args):
         return None
-    if getattr(args, "submit", False) and _requested_worktree_base(args):
-        # A queued --worktree job does not have a seat yet. Occupying --cwd
-        # (the project root) would serialize every pooled submit onto one
-        # tree; drain binds the seat and then occupies that path.
+    if getattr(args, "submit", False):
+        # A queued job does not have a seat yet. Occupying --cwd (the
+        # project root) would serialize every submit onto one tree; drain
+        # binds the captive seat and then occupies that path.
         return None
 
     occupied, unknown, occupied_state = _worktree_incumbent_reason(args)
@@ -4511,9 +4579,9 @@ def _cmd_resume(argv: list[str]) -> int:
     parser.add_argument(
         "--cwd",
         help=(
-            "Worker tree for this resume. Required when the parent record "
-            "has no worker_cwd and no --cwd in dispatch_argv; the shared "
-            "checkout is not a fallback."
+            "Worker tree for this resume. Optional when the parent record "
+            "has worker_cwd or --cwd in dispatch_argv. The shared checkout "
+            "is not a fallback."
         ),
     )
     args = parser.parse_args(argv)
@@ -4643,7 +4711,7 @@ def _resume_launch_argv(
         "--engine-session-id": source["session_id"],
         "--cwd": str(cwd),
     }
-    inject: list[str] = []
+    inject: list[str] = ["--skip-seat-reset"]
     if resume_args.unregistered_forced:
         inject.append("--unregistered-forced")
     for flag, value in (
@@ -6697,6 +6765,9 @@ LAUNCH_ARGV_CLASS: dict[str, str] = {
     "--task": "preserve",
     "--cwd": "preserve",
     "--worktree": "preserve",
+    "--at": "preserve",
+    "--in-place": "preserve",
+    "--skip-seat-reset": "inject",
     "--model": "preserve",
     "--read-only": "preserve",
     "--readonly": "preserve",
@@ -6758,6 +6829,7 @@ _REPLAY_VALUE_OPTIONS = {
     "--task",
     "--cwd",
     "--worktree",
+    "--at",
     "--model",
     "--os-sandbox",
     "--priority",
@@ -6928,6 +7000,10 @@ def _canonical_replay_argv(args, raw_argv: list[str], *, tail: Path, status_json
     worktree_base = _requested_worktree_base(args)
     if worktree_base:
         argv += ["--worktree", worktree_base]
+    if getattr(args, "in_place", False):
+        argv.append("--in-place")
+    if getattr(args, "skip_seat_reset", False):
+        argv.append("--skip-seat-reset")
     if args.capacity_wait_s is not None:
         argv += ["--capacity-wait-s", str(args.capacity_wait_s)]
     if args.account:
@@ -17374,17 +17450,39 @@ def _build_launch_parser() -> argparse.ArgumentParser:
         default=[],
         help="Comma-separated linked task/bug ids (t-/b-). May be repeated.",
     )
-    parser.add_argument("--cwd", type=_existing_cwd_arg, help="Worker working directory")
+    parser.add_argument(
+        "--cwd",
+        type=_existing_cwd_arg,
+        help=(
+            "Lock an existing tree: this controller's captive seat, the "
+            "project root (in-place), or resume's recorded worker_cwd. "
+            "Refuses any other path and never creates it."
+        ),
+    )
+    parser.add_argument(
+        "--in-place",
+        action="store_true",
+        help="Run in the project root without acquiring a captive seat.",
+    )
     parser.add_argument(
         "--worktree",
-        metavar="BASE",
+        "--at",
+        dest="worktree",
+        metavar="REF",
         help=(
-            "Acquire one pooled worktree seat prepared at git ref BASE "
-            "(HEAD, main, a commit) and run the worker there. The seat lease "
-            "fd is inherited by the worker; exhaustion refuses with every held "
-            "seat named and never falls back to `git worktree add`. Additive: "
-            "omit this flag and --cwd behaves as before."
+            "Prepare the captive seat at git ref REF (HEAD, main, a commit). "
+            "This is not an opt-in to the pool: every dispatch acquires a "
+            "seat unless --in-place or --cwd names the project root. "
+            "Default ref is origin/main when it exists, else HEAD. "
+            "Exhaustion names occupants and never falls back to "
+            "`git worktree add`."
         ),
+    )
+    parser.add_argument(
+        "--skip-seat-reset",
+        action="store_true",
+        default=False,
+        help=argparse.SUPPRESS,
     )
     parser.add_argument("--model", default=None,
                         help="Worker model id (grok-code/grok-research/moonshot/codex --model passthrough). "
@@ -17911,7 +18009,7 @@ def main(argv: list[str] | None = None) -> int:
         print(f"goalflight_dispatch: {e}", file=sys.stderr)
         return 64
     if not worker_argv:
-        print("goalflight_dispatch: no worker — use `--agent codex --prompt-file X [--cwd .]` "
+        print("goalflight_dispatch: no worker — use `--agent codex --prompt-file X` "
               "or `-- <cmd...>`", file=sys.stderr)
         return 64
 

--- a/scripts/goalflight_dispatch.py
+++ b/scripts/goalflight_dispatch.py
@@ -3567,10 +3567,13 @@ def _prepare_attempt_worktree_occupancy(args) -> str | None:
     """
     if _occupancy_exempt_read_only(args):
         return None
-    if getattr(args, "submit", False):
-        # A queued job does not have a seat yet. Occupying --cwd (the
-        # project root) would serialize every submit onto one tree; drain
-        # binds the captive seat and then occupies that path.
+    if getattr(args, "submit", False) and not getattr(args, "cwd", None) and not getattr(
+        args, "in_place", False
+    ):
+        # Default submit has no worker tree yet. Occupying the project
+        # root would serialize every queued job; drain acquires a captive
+        # seat and occupies that path. Explicit --cwd is already the
+        # worker tree and still serializes.
         return None
 
     occupied, unknown, occupied_state = _worktree_incumbent_reason(args)

--- a/scripts/goalflight_doctor.py
+++ b/scripts/goalflight_doctor.py
@@ -2913,7 +2913,18 @@ def check_worktrees(project_root: Path) -> dict:
                 rel = path.resolve().relative_to(managed_root)
             except (ValueError, OSError):
                 continue
-        if rel is None or len(rel.parts) != 1:
+        ring_label = None
+        if rel is None:
+            continue
+        if len(rel.parts) == 1:
+            leaf_name = rel.parts[0]
+        elif (
+            len(rel.parts) == 2
+            and re.fullmatch(r"s-[1-9][0-9]*", rel.parts[1])
+        ):
+            ring_label = rel.parts[0]
+            leaf_name = rel.parts[1]
+        else:
             continue
         if path.is_symlink():
             escaped.append(str(path))
@@ -2924,7 +2935,6 @@ def check_worktrees(project_root: Path) -> dict:
         except (ValueError, OSError):
             escaped.append(str(path))
             continue
-        leaf_name = rel.parts[0]
         path_text = str(resolved_path)
         paths.append(path_text)
         status = run(["git", "status", "--short"], cwd=resolved_path, timeout=4)
@@ -2937,10 +2947,14 @@ def check_worktrees(project_root: Path) -> dict:
             "head": head.get("stdout") or None,
             "branch": branch.get("stdout") or None,
         }
-        if re.fullmatch(r"wt-[1-9][0-9]*", leaf_name):
+        if re.fullmatch(r"(?:wt|s)-[1-9][0-9]*", leaf_name):
             detail["seat"] = leaf_name
+            if ring_label:
+                detail["controller_ring"] = ring_label
             lock_path = goalflight_worktree_pool.worktree_seat_lock_path(
-                project_root, leaf_name
+                project_root,
+                leaf_name,
+                controller_label=ring_label,
             )
             lock_file = None
             try:
@@ -2980,10 +2994,45 @@ def check_worktrees(project_root: Path) -> dict:
                 continue
             if not child.is_dir():
                 continue
-            child_abs = str(child.absolute())
-            child_resolved = str(child.resolve())
-            if child_abs not in registered and child_resolved not in registered_resolved:
-                blocking_paths.append(child_abs)
+            if re.fullmatch(r"wt-[1-9][0-9]*", child.name):
+                child_abs = str(child.absolute())
+                child_resolved = str(child.resolve())
+                if (
+                    child_abs not in registered
+                    and child_resolved not in registered_resolved
+                ):
+                    blocking_paths.append(child_abs)
+                continue
+            # Per-controller ring: worktrees/<label>/s-N. A directory with
+            # no captive seats is still the old ad-hoc orphan case.
+            try:
+                grandchildren = sorted(child.iterdir())
+            except OSError:
+                continue
+            seat_children = [
+                seat
+                for seat in grandchildren
+                if seat.is_dir()
+                and not seat.is_symlink()
+                and re.fullmatch(r"s-[1-9][0-9]*", seat.name)
+            ]
+            if not seat_children:
+                child_abs = str(child.absolute())
+                child_resolved = str(child.resolve())
+                if (
+                    child_abs not in registered
+                    and child_resolved not in registered_resolved
+                ):
+                    blocking_paths.append(child_abs)
+                continue
+            for seat in seat_children:
+                seat_abs = str(seat.absolute())
+                seat_resolved = str(seat.resolve())
+                if (
+                    seat_abs not in registered
+                    and seat_resolved not in registered_resolved
+                ):
+                    blocking_paths.append(seat_abs)
 
     active_dispatches: set[tuple[str, str]] = set()
     capacity_error = None

--- a/scripts/goalflight_fleet_launch_detached.py
+++ b/scripts/goalflight_fleet_launch_detached.py
@@ -691,6 +691,7 @@ def _launch(args: argparse.Namespace) -> int:
             args.dispatch_id,
             base=args.base_sha,
             managed_root=state_dir / "worktrees",
+            controller_label=args.node_id,
         )
     except goalflight_worktree_pool.WorktreeSeatError as exc:
         _update_launch_marker(

--- a/scripts/goalflight_worktree_gc.py
+++ b/scripts/goalflight_worktree_gc.py
@@ -10,10 +10,11 @@ Routine merge-down command (run from the repo after integrating a worker branch)
     python3 scripts/goalflight_worktree_gc.py --into main
     python3 scripts/goalflight_worktree_gc.py --into main --apply
 
-Registered pool seats (``<repo>/worktrees/wt-N`` with a matching seat lock)
-are maintained by ``goalflight_worktree_pool`` and are never reclaimed as
-litter. A directory merely *named* ``wt-N`` is ordinary litter: exemption is
-by registration, not basename. If registration cannot be determined, the
+Registered pool seats (captive ``<repo>/worktrees/<label>/s-N`` and legacy
+``<repo>/worktrees/wt-N`` with a matching seat lock) are maintained by
+``goalflight_worktree_pool`` and are never reclaimed as litter. A directory
+merely *named* ``s-N`` or ``wt-N`` is ordinary litter: exemption is by
+registration, not basename. If registration cannot be determined, the
 verdict is UNKNOWN and the tree is retained.
 
 Removal requires the CONJUNCTION of all four conditions:

--- a/scripts/goalflight_worktree_pool.py
+++ b/scripts/goalflight_worktree_pool.py
@@ -9,6 +9,7 @@ import fcntl
 import json
 import os
 from pathlib import Path
+import re
 import stat
 import subprocess
 from typing import TextIO
@@ -18,6 +19,10 @@ WORKTREE_SEATS_ENV = "GOALFLIGHT_WORKTREE_SEATS"
 WORKTREE_LOCK_FD_ENV = "GOALFLIGHT_WORKTREE_LOCK_FD"
 OCCUPANCY_LOCK_FD_ENV = "GOALFLIGHT_OCCUPANCY_LOCK_FD"
 OCCUPANCY_LOCK_NAME = "goalflight-worktree.lock"
+# Documented fallback when no --controller-label and no live lease label is
+# available. Stable across dispatches; do not invent a per-launch name.
+UNLABELED_CONTROLLER_RING = "unlabeled"
+SEAT_NOTES_NAMESPACE = ".goal-flight/seat"
 # Per-repository checkout ceiling, NOT a per-controller worker cap. There is no
 # such cap in this codebase and none is wanted. The old default of 4 became a
 # de-facto fan-out limit and pushed every extra dispatch onto ad-hoc
@@ -40,8 +45,10 @@ OCCUPANCY_LOCK_NAME = "goalflight-worktree.lock"
 # as a worker cap.
 DEFAULT_WORKTREE_SEATS = 24
 WORKTREE_SEAT_PREFIX = "wt-"
+CAPTIVE_SEAT_PREFIX = "s-"
 SEAT_BRANCH_PREFIX = "seat"
 QUARANTINE_REF_PREFIX = "goalflight/quarantine"
+_SAFE_RING_LABEL = re.compile(r"[A-Za-z0-9._-]+")
 
 # Three-state verdicts, same shape as goalflight_worktree_gc.py. UNKNOWN always
 # retains (refuses reset). Do not collapse "could not tell" into a green light.
@@ -72,6 +79,10 @@ class WorktreePathLockBusy(WorktreeSeatError):
 
 class WorktreePathLockUnknown(WorktreeSeatError):
     """Raised when the worktree-path lock cannot be evaluated."""
+
+
+class WorktreeCwdRefused(WorktreeSeatError):
+    """Raised when ``--cwd`` names a path the controller is not allowed to mint."""
 
 
 class WorktreePathLock:
@@ -236,24 +247,102 @@ def pass_worktree_lock_fds(env: dict[str, str] | None = None) -> tuple[int, ...]
     return tuple(fds)
 
 
+def sanitize_controller_ring_label(label: str | None) -> str:
+    """Return a filesystem-safe, stable ring label.
+
+    Empty or unsafe labels collapse to ``unlabeled``. The fallback is
+    documented and must stay the same across dispatches.
+    """
+    raw = str(label or "").strip()
+    if not raw:
+        return UNLABELED_CONTROLLER_RING
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "-", raw).strip(".-")
+    if not cleaned or cleaned in {".", ".."} or not _SAFE_RING_LABEL.fullmatch(cleaned):
+        return UNLABELED_CONTROLLER_RING
+    return cleaned[:64]
+
+
+def default_controller_ring_label(
+    explicit_label: str | None = None,
+    *,
+    project_root: Path | None = None,
+) -> str:
+    """Resolve the ring label: explicit, else repo-name fallback, else unlabeled."""
+    if explicit_label is not None and str(explicit_label).strip():
+        return sanitize_controller_ring_label(explicit_label)
+    if project_root is not None:
+        name = Path(project_root).name.strip()
+        if name:
+            return sanitize_controller_ring_label(name)
+    return UNLABELED_CONTROLLER_RING
+
+
+def default_seat_base(project_root: Path) -> str:
+    """Project default ref: ``origin/main`` when it exists, else ``HEAD``."""
+    proc = _git_proc(project_root, "rev-parse", "--verify", "origin/main^{commit}")
+    if proc is not None and proc.returncode == 0:
+        return "origin/main"
+    return "HEAD"
+
+
+def _slot_from_seat_name(name: str, prefix: str) -> int | None:
+    if not name.startswith(prefix):
+        return None
+    rest = name[len(prefix) :]
+    if rest.isdigit() and int(rest) >= 1:
+        return int(rest)
+    return None
+
+
 def pool_seat_name(path: str | Path) -> str | None:
-    """Return ``wt-N`` when the basename matches the seat naming pattern.
+    """Return ``s-N`` or legacy ``wt-N`` when the basename matches a seat pattern.
 
     A matching name is necessary but not sufficient for a maintained seat.
-    Ad-hoc worktrees can be named ``wt-5``; ask ``registered_pool_seat_verdict``.
+    Ad-hoc worktrees can be named ``s-5`` or ``wt-5``; ask
+    ``registered_pool_seat_verdict``.
     """
     name = Path(path).name
-    if not name.startswith(WORKTREE_SEAT_PREFIX):
-        return None
-    rest = name[len(WORKTREE_SEAT_PREFIX) :]
-    if rest.isdigit() and int(rest) >= 1:
+    if _slot_from_seat_name(name, CAPTIVE_SEAT_PREFIX) is not None:
+        return name
+    if _slot_from_seat_name(name, WORKTREE_SEAT_PREFIX) is not None:
         return name
     return None
 
 
 def is_pool_seat_path(path: str | Path) -> bool:
-    """True when the basename looks like ``wt-N``. Not a registration check."""
+    """True when the basename looks like ``s-N`` or ``wt-N``. Not a registration check."""
     return pool_seat_name(path) is not None
+
+
+def controller_ring_root(project_root: Path, controller_label: str | None) -> Path:
+    """Return ``{repo}/worktrees/{label}`` for a controller's captive ring."""
+    label = default_controller_ring_label(controller_label, project_root=project_root)
+    return Path(project_root).resolve() / "worktrees" / label
+
+
+def is_controller_ring_seat(
+    path: str | Path,
+    *,
+    project_root: Path,
+    controller_label: str | None,
+) -> bool:
+    """True when ``path`` is ``worktrees/{this-controller}/s-N``."""
+    try:
+        resolved = Path(path).resolve()
+        ring = controller_ring_root(project_root, controller_label).resolve()
+    except OSError:
+        return False
+    if resolved.parent != ring:
+        return False
+    return _slot_from_seat_name(resolved.name, CAPTIVE_SEAT_PREFIX) is not None
+
+
+def is_reserved_seat_notes_path(relpath: str) -> bool:
+    """True when a porcelain path is inside the reserved seat-notes namespace."""
+    text = relpath.replace("\\", "/").strip()
+    if text.startswith("./"):
+        text = text[2:]
+    return text == SEAT_NOTES_NAMESPACE or text.startswith(SEAT_NOTES_NAMESPACE + "/")
 
 
 def registered_pool_seat_verdict(
@@ -264,10 +353,12 @@ def registered_pool_seat_verdict(
     """Ask the pool whether ``path`` is a registered seat.
 
     Returns ``("yes"|"no"|"unknown", reason)``. Name is irrelevant unless the
-    path is the managed seat path ``<project>/worktrees/wt-N`` for a configured
-    slot *and* the matching lock file exists. A missing lock is "not
-    registered" (de-registered and ad-hoc trees are litter). If registration
-    cannot be determined, the verdict is unknown so a deleter retains.
+    path is a managed seat — either the captive
+    ``<project>/worktrees/<label>/s-N`` ring or the legacy
+    ``<project>/worktrees/wt-N`` layout — *and* the matching lock file exists.
+    A missing lock is "not registered" (de-registered and ad-hoc trees are
+    litter). If registration cannot be determined, the verdict is unknown so
+    a deleter retains.
     """
     try:
         root = project_root.resolve()
@@ -285,25 +376,41 @@ def registered_pool_seat_verdict(
         return "unknown", f"managed worktree root unresolvable ({exc})"
 
     try:
-        if resolved.parent != managed_root:
-            return (
-                "no",
-                f"{resolved} is not under the managed seat root {managed_root}",
-            )
+        rel = resolved.relative_to(managed_root)
+    except ValueError:
+        return (
+            "no",
+            f"{resolved} is not under the managed seat root {managed_root}",
+        )
     except OSError as exc:
         return "unknown", f"managed seat path could not be compared ({exc})"
 
-    seat_name = pool_seat_name(resolved)
-    if seat_name is None:
-        return "no", f"{resolved.name} is not a pool seat name"
+    parts = rel.parts
+    lock_subdir: str | None = None
+    if len(parts) == 1:
+        seat_name = pool_seat_name(parts[0])
+        prefix = WORKTREE_SEAT_PREFIX
+        if seat_name is None or _slot_from_seat_name(seat_name, prefix) is None:
+            return "no", f"{resolved.name} is not a pool seat name"
+    elif len(parts) == 2:
+        seat_name = pool_seat_name(parts[1])
+        prefix = CAPTIVE_SEAT_PREFIX
+        if seat_name is None or _slot_from_seat_name(seat_name, prefix) is None:
+            return "no", f"{resolved.name} is not a pool seat name"
+        lock_subdir = parts[0]
+    else:
+        return (
+            "no",
+            f"{resolved} is not a managed seat path under {managed_root}",
+        )
 
     try:
         seat_limit = configured_worktree_seats()
     except WorktreeSeatError as exc:
         return "unknown", f"seat configuration unreadable ({exc})"
 
-    slot = int(seat_name[len(WORKTREE_SEAT_PREFIX) :])
-    if slot > seat_limit:
+    slot = _slot_from_seat_name(seat_name, prefix)
+    if slot is None or slot > seat_limit:
         return (
             "no",
             f"{seat_name} is outside the configured seat range 1..{seat_limit}",
@@ -313,6 +420,8 @@ def registered_pool_seat_verdict(
         lock_root = _git_common_dir(root) / "goalflight-worktree-seat-locks"
     except WorktreeSeatError as exc:
         return "unknown", f"seat lock directory unreadable ({exc})"
+    if lock_subdir:
+        lock_root = lock_root / lock_subdir
 
     lock_path = lock_root / f"{seat_name}.lock"
     try:
@@ -394,9 +503,110 @@ def _git_dir(cwd: Path) -> Path:
     return (raw if raw.is_absolute() else cwd / raw).resolve()
 
 
-def worktree_seat_lock_path(project_root: Path, seat_name: str) -> Path:
-    """Return the per-repository lock path for an already-named seat."""
-    return _git_dir(project_root.resolve()) / "goalflight-worktree-seat-locks" / f"{seat_name}.lock"
+def is_captive_seat_name(name: str) -> bool:
+    """True when ``name`` is a captive ``s-N`` seat."""
+    return _slot_from_seat_name(name, CAPTIVE_SEAT_PREFIX) is not None
+
+
+def _seat_lock_root(project_root: Path, *, controller_label: str | None = None) -> Path:
+    root = _git_dir(project_root.resolve()) / "goalflight-worktree-seat-locks"
+    if controller_label is None:
+        return root
+    return root / sanitize_controller_ring_label(controller_label)
+
+
+def worktree_seat_lock_path(
+    project_root: Path,
+    seat_name: str,
+    *,
+    controller_label: str | None = None,
+) -> Path:
+    """Return the per-repository lock path for an already-named seat.
+
+    Captive ``s-N`` seats store locks under ``{lock_root}/{label}/s-N.lock``.
+    Legacy ``wt-N`` seats keep ``{lock_root}/wt-N.lock`` so in-flight
+    workers are not evicted during the overlap window.
+    """
+    if controller_label is not None and is_captive_seat_name(seat_name):
+        return _seat_lock_root(project_root, controller_label=controller_label) / f"{seat_name}.lock"
+    return _seat_lock_root(project_root) / f"{seat_name}.lock"
+
+
+def _ring_state_path(lock_root: Path) -> Path:
+    return lock_root / "ring.json"
+
+
+def _read_ring_hwm(lock_root: Path) -> int:
+    path = _ring_state_path(lock_root)
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError):
+        return 0
+    if not isinstance(payload, dict):
+        return 0
+    try:
+        hwm = int(payload.get("hwm") or 0)
+    except (TypeError, ValueError):
+        return 0
+    return max(0, hwm)
+
+
+def _write_ring_hwm(lock_root: Path, hwm: int) -> None:
+    path = _ring_state_path(lock_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f"{path.name}.tmp.{os.getpid()}")
+    tmp.write_text(json.dumps({"hwm": int(hwm)}, sort_keys=True) + "\n", encoding="utf-8")
+    tmp.replace(path)
+
+
+def _porcelain_relpaths(line: str) -> list[str]:
+    text = line.rstrip("\n")
+    if len(text) < 4:
+        return []
+    rest = text[3:]
+    if " -> " in rest:
+        return [part.replace("\\", "/").strip() for part in rest.split(" -> ", 1)]
+    return [rest.replace("\\", "/").strip()]
+
+
+def _porcelain_is_product(line: str) -> bool:
+    paths = _porcelain_relpaths(line)
+    if not paths:
+        return bool(line.strip())
+    return any(not is_reserved_seat_notes_path(path) for path in paths)
+
+
+def classify_dispatch_cwd(
+    cwd: Path,
+    *,
+    project_root: Path,
+    controller_label: str | None,
+) -> str:
+    """Classify ``--cwd`` as ``in-place``, ``ring-seat``, or ``refuse``.
+
+    In-place requires ``cwd`` to be the git toplevel of that path *and*
+    equal to ``project_root``. A non-git directory is never in-place even
+    when ``resolve_project_root`` would treat it as its own root.
+    """
+    try:
+        resolved = Path(cwd).expanduser().resolve()
+        root = Path(project_root).resolve()
+    except OSError:
+        return "refuse"
+    proc = _git_proc(resolved, "rev-parse", "--show-toplevel")
+    if (
+        proc is not None
+        and proc.returncode == 0
+        and proc.stdout.strip()
+    ):
+        top = Path(proc.stdout.strip()).resolve()
+        if top == resolved and top == root:
+            return "in-place"
+    if is_controller_ring_seat(
+        resolved, project_root=root, controller_label=controller_label
+    ):
+        return "ring-seat"
+    return "refuse"
 
 
 def _verify_project_root(project_root: Path) -> None:
@@ -521,7 +731,11 @@ def check_seat_cleanliness(worktree_path: Path) -> dict[str, str]:
         return _condition(
             UNKNOWN, f"git status failed ({detail}), so cleanliness is unknown"
         )
-    dirty = [line for line in proc.stdout.splitlines() if line.strip()]
+    dirty = [
+        line
+        for line in proc.stdout.splitlines()
+        if line.strip() and _porcelain_is_product(line)
+    ]
     if dirty:
         return _condition(
             NO,
@@ -666,7 +880,9 @@ def _prepare_seat_checkout(
     worktree_path: Path, *, branch: str, base_commit: str
 ) -> None:
     _git(worktree_path, "checkout", "-f", "-B", branch, base_commit)
-    _git(worktree_path, "clean", "-fd")
+    # Never ``git clean -fdx``. Preserve the reserved notes namespace even
+    # when a temp repo has not gitignored ``.goal-flight/``.
+    _git(worktree_path, "clean", "-fd", "-e", ".goal-flight")
 
 
 def _assert_seat_on_named_branch(worktree_path: Path, *, seat_name: str, branch: str) -> str:
@@ -690,10 +906,21 @@ def _quarantine_dirty_worktree(
     abandoned_dispatch_id: str,
 ) -> str | None:
     dirty = _git(worktree_path, "status", "--porcelain=v1", "--untracked-files=all")
-    if not dirty:
+    product = [
+        line for line in dirty.splitlines() if line.strip() and _porcelain_is_product(line)
+    ]
+    if not product:
         return None
 
-    _git(worktree_path, "add", "-A")
+    _git(
+        worktree_path,
+        "add",
+        "-A",
+        "--",
+        ".",
+        ":(exclude).goal-flight",
+        ":(exclude).goal-flight/**",
+    )
     tree = _git(worktree_path, "write-tree")
     parent = _git(worktree_path, "rev-parse", "HEAD")
     parent_tree = _git(worktree_path, "rev-parse", "HEAD^{tree}")
@@ -743,20 +970,116 @@ def _quarantine_dirty_worktree(
     return branch
 
 
+def _prepare_claimed_seat(
+    *,
+    project_root: Path,
+    worktree_path: Path,
+    seat_name: str,
+    lock_file: TextIO,
+    dispatch_id: str,
+    prior_dispatch_id: str,
+    branch: str,
+    base_commit: str,
+    reset: bool,
+) -> WorktreeSeatLease:
+    existing = worktree_path.exists() or worktree_path.is_symlink()
+    if existing:
+        _verify_existing_seat(project_root, worktree_path)
+        if reset:
+            safety = evaluate_seat_reset_safety(
+                worktree_path,
+                base_commit=base_commit,
+                new_branch=branch,
+            )
+            if safety["decision"] != "reset":
+                raise WorktreeSeatResetRefused(safety["reason"])
+    elif not reset:
+        raise WorktreeCwdRefused(
+            f"refusing to create missing --cwd {worktree_path}; "
+            "resume and occupy only attach an existing tree"
+        )
+    _write_occupant(lock_file, seat_name=seat_name, dispatch_id=dispatch_id)
+    if not existing:
+        _create_seat_worktree(
+            project_root,
+            worktree_path,
+            branch=branch,
+            base_commit=base_commit,
+        )
+        _verify_existing_seat(project_root, worktree_path)
+    if not reset:
+        actual = _git(worktree_path, "rev-parse", "--abbrev-ref", "HEAD")
+        return WorktreeSeatLease(
+            path=worktree_path,
+            seat_name=seat_name,
+            dispatch_id=dispatch_id,
+            lock_file=lock_file,
+            quarantine_branch=None,
+            branch=actual,
+        )
+    quarantine_branch = _quarantine_dirty_worktree(
+        worktree_path,
+        seat_name=seat_name,
+        abandoned_dispatch_id=prior_dispatch_id,
+    )
+    _prepare_seat_checkout(worktree_path, branch=branch, base_commit=base_commit)
+    remaining = _git(
+        worktree_path,
+        "status",
+        "--porcelain=v1",
+        "--untracked-files=all",
+    )
+    leftover = [
+        line
+        for line in remaining.splitlines()
+        if line.strip() and _porcelain_is_product(line)
+    ]
+    if leftover:
+        raise WorktreeSeatError(
+            f"worktree seat {seat_name} is not clean after acquire-time reset"
+        )
+    actual_branch = _assert_seat_on_named_branch(
+        worktree_path, seat_name=seat_name, branch=branch
+    )
+    return WorktreeSeatLease(
+        path=worktree_path,
+        seat_name=seat_name,
+        dispatch_id=dispatch_id,
+        lock_file=lock_file,
+        quarantine_branch=quarantine_branch,
+        branch=actual_branch,
+    )
+
+
 def acquire_worktree_seat(
     project_root: Path,
     dispatch_id: str,
     *,
-    base: str = "HEAD",
+    base: str | None = None,
     managed_root: Path | None = None,
+    controller_label: str | None = None,
+    reset: bool = True,
+    occupy_path: Path | None = None,
 ) -> WorktreeSeatLease:
-    """Acquire, prepare, and return one seat without ever exceeding the range."""
+    """Acquire one captive ``s-N`` seat. Never mint past the fuse or HWM.
+
+    Isolation is not a mode. New acquires grow this controller's ring to the
+    live nonterminal high-water mark and reuse those paths forever. Exhaustion
+    names occupants and refuses ``git worktree add``.
+    """
     project_root = project_root.resolve()
     _verify_project_root(project_root)
     seat_limit = configured_worktree_seats()
-    base_commit = _git(project_root, "rev-parse", "--verify", f"{base}^{{commit}}")
+    label = default_controller_ring_label(controller_label, project_root=project_root)
+    resolved_base = base if base is not None else default_seat_base(project_root)
+    base_commit = _git(project_root, "rev-parse", "--verify", f"{resolved_base}^{{commit}}")
     branch = seat_branch_name(dispatch_id)
 
+    worktrees_root = project_root / "worktrees"
+    if worktrees_root.is_symlink():
+        raise WorktreeSeatError(
+            f"managed worktree root must not be a symlink: {worktrees_root}"
+        )
     if managed_root is not None:
         managed_root = managed_root.expanduser()
         if managed_root.is_symlink():
@@ -765,25 +1088,22 @@ def acquire_worktree_seat(
             )
         managed_root = managed_root.resolve(strict=False)
     else:
-        managed_root = project_root / "worktrees"
+        managed_root = controller_ring_root(project_root, label)
     if managed_root.is_symlink():
         raise WorktreeSeatError(f"managed worktree root must not be a symlink: {managed_root}")
     if managed_root.exists() and not managed_root.is_dir():
         raise WorktreeSeatError(f"managed worktree root is not a directory: {managed_root}")
-    managed_root.mkdir(parents=True, exist_ok=True)
+    if occupy_path is None:
+        managed_root.mkdir(parents=True, exist_ok=True)
 
-    lock_root = _git_dir(project_root) / "goalflight-worktree-seat-locks"
+    lock_root = _seat_lock_root(project_root, controller_label=label)
     if lock_root.is_symlink():
         raise WorktreeSeatError(f"worktree seat lock root must not be a symlink: {lock_root}")
     if lock_root.exists() and not lock_root.is_dir():
         raise WorktreeSeatError(f"worktree seat lock root is not a directory: {lock_root}")
     lock_root.mkdir(parents=True, exist_ok=True)
 
-    flags = os.O_RDWR | os.O_CREAT
-    if hasattr(os, "O_CLOEXEC"):
-        flags |= os.O_CLOEXEC
-    if hasattr(os, "O_NOFOLLOW"):
-        flags |= os.O_NOFOLLOW
+    flags = _lock_open_flags()
     allocation_lock_path = lock_root / "allocation.lock"
     try:
         allocation_fd = os.open(allocation_lock_path, flags, 0o600)
@@ -797,10 +1117,95 @@ def acquire_worktree_seat(
         # ownership; it only ensures a contender never reads an occupant's old
         # diagnostic metadata between that occupant's flock and metadata write.
         fcntl.flock(allocation_file.fileno(), fcntl.LOCK_EX)
+
+        if occupy_path is not None:
+            worktree_path = Path(occupy_path).expanduser().resolve(strict=False)
+            if not worktree_path.exists():
+                raise WorktreeCwdRefused(
+                    f"refusing to create missing --cwd {worktree_path}"
+                )
+            seat_name = worktree_path.name
+            if not is_captive_seat_name(seat_name) and _slot_from_seat_name(
+                seat_name, WORKTREE_SEAT_PREFIX
+            ) is None:
+                raise WorktreeCwdRefused(
+                    f"--cwd {worktree_path} is not a captive seat in "
+                    f"{managed_root}; pass --in-place for the project root"
+                )
+            if worktree_path.parent.resolve() != managed_root.resolve():
+                raise WorktreeCwdRefused(
+                    f"--cwd {worktree_path} is not in this controller ring "
+                    f"{managed_root}"
+                )
+            lock_path = lock_root / f"{seat_name}.lock"
+            try:
+                lock_fd = os.open(lock_path, flags, 0o600)
+            except OSError as exc:
+                raise WorktreeSeatError(
+                    f"cannot open worktree seat lock {lock_path}: {exc}"
+                ) from exc
+            lock_file = os.fdopen(lock_fd, "r+", encoding="utf-8")
+            try:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except BlockingIOError:
+                occupant = _occupant_description(lock_file, seat_name)
+                lock_file.close()
+                raise WorktreeSeatUnavailable(
+                    f"worktree seat {seat_name} is held: {occupant}; "
+                    "refusing to git worktree add a new unmanaged path"
+                )
+            try:
+                prior_dispatch_id = str(
+                    _lock_metadata(lock_file).get("dispatch_id") or "unknown-dispatch"
+                )
+                return _prepare_claimed_seat(
+                    project_root=project_root,
+                    worktree_path=worktree_path,
+                    seat_name=seat_name,
+                    lock_file=lock_file,
+                    dispatch_id=dispatch_id,
+                    prior_dispatch_id=prior_dispatch_id,
+                    branch=branch,
+                    base_commit=base_commit,
+                    reset=reset,
+                )
+            except BaseException:
+                lock_file.close()
+                raise
+
         occupants: list[str] = []
-        refused: list[str] = []
         for slot in range(1, seat_limit + 1):
-            seat_name = f"{WORKTREE_SEAT_PREFIX}{slot}"
+            seat_name = f"{CAPTIVE_SEAT_PREFIX}{slot}"
+            lock_path = lock_root / f"{seat_name}.lock"
+            if not lock_path.exists():
+                continue
+            try:
+                probe_fd = os.open(lock_path, flags, 0o600)
+            except OSError:
+                continue
+            probe_file = os.fdopen(probe_fd, "r+", encoding="utf-8")
+            try:
+                fcntl.flock(probe_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except BlockingIOError:
+                occupants.append(_occupant_description(probe_file, seat_name))
+            probe_file.close()
+
+        live = len(occupants) + 1
+        if live > seat_limit:
+            held = ", ".join(occupants)
+            raise WorktreeSeatUnavailable(
+                f"all {seat_limit} worktree seats are held: {held}; "
+                "refusing to git worktree add a new unmanaged path"
+            )
+        hwm = max(_read_ring_hwm(lock_root), live)
+        if hwm > seat_limit:
+            hwm = seat_limit
+        _write_ring_hwm(lock_root, hwm)
+
+        refused: list[str] = []
+        occupants = []
+        for slot in range(1, hwm + 1):
+            seat_name = f"{CAPTIVE_SEAT_PREFIX}{slot}"
             worktree_path = managed_root / seat_name
             lock_path = lock_root / f"{seat_name}.lock"
             try:
@@ -821,56 +1226,58 @@ def acquire_worktree_seat(
                 prior_dispatch_id = str(
                     _lock_metadata(lock_file).get("dispatch_id") or "unknown-dispatch"
                 )
-                existing = worktree_path.exists() or worktree_path.is_symlink()
-                if existing:
-                    _verify_existing_seat(project_root, worktree_path)
-                    safety = evaluate_seat_reset_safety(
-                        worktree_path,
-                        base_commit=base_commit,
-                        new_branch=branch,
-                    )
-                    if safety["decision"] != "reset":
-                        refused.append(f"{seat_name}: {safety['reason']}")
-                        lock_file.close()
-                        continue
-                _write_occupant(lock_file, seat_name=seat_name, dispatch_id=dispatch_id)
-                if not existing:
-                    _create_seat_worktree(
-                        project_root,
-                        worktree_path,
-                        branch=branch,
-                        base_commit=base_commit,
-                    )
-                    _verify_existing_seat(project_root, worktree_path)
-
-                quarantine_branch = _quarantine_dirty_worktree(
-                    worktree_path,
+                return _prepare_claimed_seat(
+                    project_root=project_root,
+                    worktree_path=worktree_path,
                     seat_name=seat_name,
-                    abandoned_dispatch_id=prior_dispatch_id,
-                )
-                _prepare_seat_checkout(
-                    worktree_path, branch=branch, base_commit=base_commit
-                )
-                remaining = _git(
-                    worktree_path,
-                    "status",
-                    "--porcelain=v1",
-                    "--untracked-files=all",
-                )
-                if remaining:
-                    raise WorktreeSeatError(
-                        f"worktree seat {seat_name} is not clean after acquire-time reset"
-                    )
-                actual_branch = _assert_seat_on_named_branch(
-                    worktree_path, seat_name=seat_name, branch=branch
-                )
-                return WorktreeSeatLease(
-                    path=worktree_path,
-                    seat_name=seat_name,
-                    dispatch_id=dispatch_id,
                     lock_file=lock_file,
-                    quarantine_branch=quarantine_branch,
-                    branch=actual_branch,
+                    dispatch_id=dispatch_id,
+                    prior_dispatch_id=prior_dispatch_id,
+                    branch=branch,
+                    base_commit=base_commit,
+                    reset=reset,
+                )
+            except WorktreeSeatResetRefused as exc:
+                refused.append(f"{seat_name}: {exc}")
+                lock_file.close()
+                continue
+            except BaseException:
+                lock_file.close()
+                raise
+
+        while hwm < seat_limit and refused and len(occupants) + 1 <= seat_limit:
+            hwm += 1
+            _write_ring_hwm(lock_root, hwm)
+            seat_name = f"{CAPTIVE_SEAT_PREFIX}{hwm}"
+            worktree_path = managed_root / seat_name
+            lock_path = lock_root / f"{seat_name}.lock"
+            try:
+                lock_fd = os.open(lock_path, flags, 0o600)
+            except OSError as exc:
+                raise WorktreeSeatError(
+                    f"cannot open worktree seat lock {lock_path}: {exc}"
+                ) from exc
+            lock_file = os.fdopen(lock_fd, "r+", encoding="utf-8")
+            try:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except BlockingIOError:
+                occupants.append(_occupant_description(lock_file, seat_name))
+                lock_file.close()
+                break
+            try:
+                prior_dispatch_id = str(
+                    _lock_metadata(lock_file).get("dispatch_id") or "unknown-dispatch"
+                )
+                return _prepare_claimed_seat(
+                    project_root=project_root,
+                    worktree_path=worktree_path,
+                    seat_name=seat_name,
+                    lock_file=lock_file,
+                    dispatch_id=dispatch_id,
+                    prior_dispatch_id=prior_dispatch_id,
+                    branch=branch,
+                    base_commit=base_commit,
+                    reset=reset,
                 )
             except WorktreeSeatResetRefused as exc:
                 refused.append(f"{seat_name}: {exc}")
@@ -884,15 +1291,16 @@ def acquire_worktree_seat(
         lost = "; ".join(refused)
         if refused and not occupants:
             raise WorktreeSeatResetRefused(
-                f"all {seat_limit} worktree seats would lose work on reset: {lost}"
+                f"all {hwm} worktree seats would lose work on reset: {lost}"
             )
         if refused:
             raise WorktreeSeatResetRefused(
-                f"all {seat_limit} worktree seats are unavailable: "
+                f"all {hwm} worktree seats are unavailable: "
                 f"held: {held or 'none'}; refusing reset: {lost}"
             )
         raise WorktreeSeatUnavailable(
-            f"all {seat_limit} worktree seats are held: {held}"
+            f"all {seat_limit} worktree seats are held: {held}; "
+            "refusing to git worktree add a new unmanaged path"
         )
     finally:
         allocation_file.close()

--- a/scripts/goalflight_worktree_pool.py
+++ b/scripts/goalflight_worktree_pool.py
@@ -584,9 +584,17 @@ def classify_dispatch_cwd(
 ) -> str:
     """Classify ``--cwd`` as ``in-place``, ``ring-seat``, or ``refuse``.
 
-    In-place requires ``cwd`` to be the git toplevel of that path *and*
-    equal to ``project_root``. A non-git directory is never in-place even
-    when ``resolve_project_root`` would treat it as its own root.
+    In-place is the project root of *this* dispatch:
+
+    - ``cwd`` is that path's git toplevel and equals ``project_root``, or
+    - ``cwd`` is not inside any git checkout and equals ``project_root``
+      (a non-git project identity, the same fallback
+      ``resolve_project_root`` uses).
+
+    A nested path under another git checkout — ``.cache/worktrees/foo``,
+    an ad-hoc linked worktree of the same repo, ``/tmp`` clones — is not
+    in-place. Those are the sprawl paths: refuse unless they are a seat
+    in this controller's ring.
     """
     try:
         resolved = Path(cwd).expanduser().resolve()
@@ -594,14 +602,17 @@ def classify_dispatch_cwd(
     except OSError:
         return "refuse"
     proc = _git_proc(resolved, "rev-parse", "--show-toplevel")
-    if (
-        proc is not None
-        and proc.returncode == 0
-        and proc.stdout.strip()
-    ):
-        top = Path(proc.stdout.strip()).resolve()
-        if top == resolved and top == root:
+    git_top: Path | None = None
+    if proc is not None and proc.returncode == 0 and proc.stdout.strip():
+        try:
+            git_top = Path(proc.stdout.strip()).resolve()
+        except OSError:
+            git_top = None
+    if git_top is not None:
+        if git_top == resolved and git_top == root:
             return "in-place"
+    elif resolved == root:
+        return "in-place"
     if is_controller_ring_seat(
         resolved, project_root=root, controller_label=controller_label
     ):

--- a/tests/python/test_dispatch_argv_fidelity.py
+++ b/tests/python/test_dispatch_argv_fidelity.py
@@ -613,6 +613,7 @@ def test_preserve_class_flags_survive_original_argv_replay(tmp_path: Path) -> No
     dummies = {
         "--cwd": str(tmp_path),
         "--worktree": "HEAD",
+        "--at": "HEAD",
         "--os-sandbox": "off",
         "--model": "gpt-test",
         "--priority": "bulk",

--- a/tests/python/test_dispatch_worktree_occupancy.py
+++ b/tests/python/test_dispatch_worktree_occupancy.py
@@ -230,17 +230,33 @@ def _temp_dir(prefix: str | None = None, *, dir: Path | None = None) -> _Reaping
     return _ReapingTempDir(prefix=prefix, dir=dir)
 
 
-def _non_temp_tree(prefix: str) -> tempfile.TemporaryDirectory:
+@contextlib.contextmanager
+def _non_temp_tree(prefix: str):
     """A worker tree outside the macOS temp root.
 
     An explicit --read-only dispatch runs the OS-sandbox boundary check, which
     refuses cwds inside the allowed temp root (it cannot separate the workspace
     from everything else a temp root lets the worker write). The repo's
     gitignored docs-private/ is the established scratch location for this.
+
+    The tree is its own git toplevel so ``--cwd`` is in-place, not a nested
+    path under this repository (captive-ring lock).
     """
     scratch = ROOT / "docs-private"
     scratch.mkdir(exist_ok=True)
-    return _temp_dir(prefix=prefix, dir=scratch)
+    with _temp_dir(prefix=prefix, dir=scratch) as td:
+        tree = Path(td)
+        init = subprocess.run(
+            ["git", "init", "-b", "main"],
+            cwd=str(tree),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+        )
+        if init.returncode != 0:
+            raise AssertionError(f"git init failed: {init.stderr or init.stdout}")
+        yield td
 
 
 def _ledger_record(tmp: Path, dispatch_id: str) -> dict:

--- a/tests/python/test_dispatch_worktree_pool.py
+++ b/tests/python/test_dispatch_worktree_pool.py
@@ -93,10 +93,6 @@ def _dispatch_cmd(tmp: Path, repo: Path, dispatch_id: str, *worker: str) -> list
         "test-dispatch",
         "--dispatch-id",
         dispatch_id,
-        "--cwd",
-        str(repo),
-        "--worktree",
-        "HEAD",
         "--launch-detached",
         "--poll-secs",
         "0.2",
@@ -121,7 +117,7 @@ def test_worktree_exhaustion_refuses_honestly_and_does_not_add(
     try:
         proc = subprocess.run(
             _dispatch_cmd(tmp_path, repo, "need-a-seat", sys.executable, "-c", "print('nope')"),
-            cwd=str(ROOT),
+            cwd=str(repo),
             env=env,
             text=True,
             stdout=subprocess.PIPE,
@@ -132,9 +128,9 @@ def test_worktree_exhaustion_refuses_honestly_and_does_not_add(
         assert proc.returncode == 2, combined
         assert "all 1 worktree seats are held" in combined, combined
         assert "held-occupant" in combined, combined
-        assert "wt-1" in combined, combined
+        assert "s-1" in combined, combined
         assert "refusing to git worktree add" in combined, combined
-        assert not (repo / "worktrees" / "wt-2").exists()
+        assert not (repo / "worktrees" / "repo" / "s-2").exists()
     finally:
         holder.release()
 
@@ -168,7 +164,7 @@ def test_seat_survives_for_worker_lifetime_then_frees_on_death(
             worker,
             str(marker),
         ),
-        cwd=str(ROOT),
+        cwd=str(repo),
         env=env,
         text=True,
         stdout=subprocess.PIPE,
@@ -178,7 +174,7 @@ def test_seat_survives_for_worker_lifetime_then_frees_on_death(
     combined = proc.stdout + proc.stderr
     assert proc.returncode == 0, combined
     launched = _launched_payload(proc.stdout)
-    assert launched.get("worktree_seat") == "wt-1", launched
+    assert launched.get("worktree_seat") == "s-1", launched
     deadline = time.time() + 10
     while time.time() < deadline and not marker.exists():
         time.sleep(0.05)
@@ -188,7 +184,7 @@ def test_seat_survives_for_worker_lifetime_then_frees_on_death(
         try:
             goalflight_worktree_pool.acquire_worktree_seat(repo, "blocked-while-live")
         except goalflight_worktree_pool.WorktreeSeatUnavailable as exc:
-            assert "inherit-seat" in str(exc) or "wt-1" in str(exc)
+            assert "inherit-seat" in str(exc) or "s-1" in str(exc)
         else:
             raise AssertionError("live worker did not hold the kernel seat")
         os.kill(worker_pid, signal.SIGKILL)
@@ -203,7 +199,7 @@ def test_seat_survives_for_worker_lifetime_then_frees_on_death(
             repo, "after-worker-death"
         )
         try:
-            assert replacement.path.name == "wt-1"
+            assert replacement.path.name == "s-1"
         finally:
             replacement.release()
     finally:
@@ -240,7 +236,7 @@ def test_dispatch_quarantines_dirty_seat_instead_of_destroying(
             "-c",
             worker,
         ),
-        cwd=str(ROOT),
+        cwd=str(repo),
         env=env,
         text=True,
         stdout=subprocess.PIPE,
@@ -250,7 +246,7 @@ def test_dispatch_quarantines_dirty_seat_instead_of_destroying(
     combined = proc.stdout + proc.stderr
     assert proc.returncode == 0, combined
     launched = _launched_payload(proc.stdout)
-    assert launched.get("worktree_seat") == "wt-1", launched
+    assert launched.get("worktree_seat") == "s-1", launched
     deadline = time.time() + 10
     while time.time() < deadline and not marker.exists():
         time.sleep(0.05)
@@ -262,7 +258,7 @@ def test_dispatch_quarantines_dirty_seat_instead_of_destroying(
         "refs/heads/goalflight/quarantine/",
     ).splitlines()
     assert len(branches) == 1, branches
-    assert "wt-1" in branches[0]
+    assert "s-1" in branches[0]
     assert _git(repo, "show", f"{branches[0]}:abandoned.txt") == "preserve me"
 
 
@@ -294,7 +290,7 @@ def test_cwd_without_worktree_does_not_acquire_a_seat(
             "-c",
             f"from pathlib import Path; Path({str(marker)!r}).write_text('ok')",
         ],
-        cwd=str(ROOT),
+        cwd=str(repo),
         env=env,
         text=True,
         stdout=subprocess.PIPE,
@@ -347,7 +343,7 @@ def test_worktree_launch_does_not_fail_caffeinate_on_stale_lock_fd(
             "-c",
             worker,
         ),
-        cwd=str(ROOT),
+        cwd=str(repo),
         env=env,
         text=True,
         stdout=subprocess.PIPE,
@@ -396,7 +392,7 @@ def test_two_worktree_launches_do_not_serialize_on_occupancy(
 
     pa = subprocess.Popen(
         _dispatch_cmd(tmp_path, repo, "wt-conc-a", sys.executable, "-c", worker(marker_a)),
-        cwd=str(ROOT),
+        cwd=str(repo),
         env=env,
         text=True,
         stdout=subprocess.PIPE,
@@ -404,7 +400,7 @@ def test_two_worktree_launches_do_not_serialize_on_occupancy(
     )
     pb = subprocess.Popen(
         _dispatch_cmd(tmp_path, repo, "wt-conc-b", sys.executable, "-c", worker(marker_b)),
-        cwd=str(ROOT),
+        cwd=str(repo),
         env=env,
         text=True,
         stdout=subprocess.PIPE,
@@ -422,8 +418,8 @@ def test_two_worktree_launches_do_not_serialize_on_occupancy(
         cwd_a = marker_a.read_text(encoding="utf-8").strip()
         cwd_b = marker_b.read_text(encoding="utf-8").strip()
         assert cwd_a != cwd_b, (cwd_a, cwd_b)
-        assert Path(cwd_a).name.startswith("wt-")
-        assert Path(cwd_b).name.startswith("wt-")
+        assert Path(cwd_a).name.startswith("s-")
+        assert Path(cwd_b).name.startswith("s-")
         release.write_text("go", encoding="utf-8")
         out_a, err_a = pa.communicate(timeout=30)
         out_b, err_b = pb.communicate(timeout=30)
@@ -459,7 +455,7 @@ def test_raw_worker_process_cwd_is_the_leased_seat(
             "-c",
             worker,
         ),
-        cwd=str(ROOT),
+        cwd=str(repo),
         env=env,
         text=True,
         stdout=subprocess.PIPE,
@@ -534,7 +530,7 @@ def test_dispatch_payload_includes_worktree_branch(
             "-c",
             worker,
         ),
-        cwd=str(ROOT),
+        cwd=str(repo),
         env=env,
         text=True,
         stdout=subprocess.PIPE,
@@ -546,7 +542,7 @@ def test_dispatch_payload_includes_worktree_branch(
     started, launched = _payloads(proc.stdout)
     assert started.get("worktree_branch") == "seat/report-branch", started
     assert launched.get("worktree_branch") == "seat/report-branch", launched
-    assert launched.get("worktree_seat") == "wt-1", launched
+    assert launched.get("worktree_seat") == "s-1", launched
     deadline = time.time() + 10
     while time.time() < deadline and not marker.exists():
         time.sleep(0.05)
@@ -599,7 +595,7 @@ def test_detached_ahead_seat_is_skipped_for_a_free_sibling(
 
     second = goalflight_worktree_pool.acquire_worktree_seat(repo, "use-wt-2")
     try:
-        assert second.path.name == "wt-2"
+        assert second.path.name == "s-2"
         assert second.branch == "seat/use-wt-2"
         assert _git(first.path, "rev-parse", "HEAD") == sha
         assert _git(first.path, "rev-parse", "--abbrev-ref", "HEAD") == "HEAD"
@@ -693,3 +689,159 @@ def test_claude_preset_has_no_cwd_flag_seat_is_process_cwd() -> None:
     assert argv[:1] == ["claude"]
     assert "--cwd" not in argv
     assert "-C" not in argv
+
+
+def test_default_dispatch_acquires_captive_seat(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("GOALFLIGHT_WORKTREE_SEATS", "2")
+    repo = _make_repo(tmp_path)
+    env = _env(tmp_path, seats=2)
+    marker = tmp_path / "default-cwd"
+    worker = (
+        "from pathlib import Path; import os; "
+        f"Path({str(marker)!r}).write_text(os.getcwd())"
+    )
+    proc = subprocess.run(
+        _dispatch_cmd(tmp_path, repo, "default-seat", sys.executable, "-c", worker),
+        cwd=str(repo),
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=30,
+    )
+    combined = proc.stdout + proc.stderr
+    assert proc.returncode == 0, combined
+    launched = _launched_payload(proc.stdout)
+    assert launched.get("worktree_seat") == "s-1", launched
+    seat = Path(launched["worktree_path"]).resolve()
+    assert seat.name == "s-1"
+    assert seat.parent.name == repo.name
+    deadline = time.time() + 10
+    while time.time() < deadline and not marker.exists():
+        time.sleep(0.05)
+    assert marker.exists(), combined
+    assert Path(marker.read_text(encoding="utf-8")).resolve() == seat
+    listed = _git(repo, "worktree", "list", "--porcelain")
+    assert str(seat) in listed
+    assert "bt-" not in listed
+
+
+def test_sequential_default_dispatch_reuses_one_seat(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("GOALFLIGHT_WORKTREE_SEATS", "4")
+    repo = _make_repo(tmp_path)
+    env = _env(tmp_path, seats=4)
+    paths = []
+    for name in ("seq-a", "seq-b"):
+        marker = tmp_path / f"{name}.cwd"
+        worker = (
+            "from pathlib import Path; import os; "
+            f"Path({str(marker)!r}).write_text(os.getcwd()); "
+            "print('COMPLETE: seq — ok', flush=True)"
+        )
+        proc = subprocess.run(
+            _dispatch_cmd(tmp_path, repo, name, sys.executable, "-c", worker),
+            cwd=str(repo),
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=30,
+        )
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+        launched = _launched_payload(proc.stdout)
+        paths.append(Path(launched["worktree_path"]).resolve())
+        deadline = time.time() + 10
+        while time.time() < deadline and not marker.exists():
+            time.sleep(0.05)
+    assert paths[0] == paths[1]
+    assert paths[0].name == "s-1"
+    assert not (paths[0].parent / "s-2").exists()
+
+
+def test_cwd_to_cache_worktree_is_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("GOALFLIGHT_WORKTREE_SEATS", "2")
+    repo = _make_repo(tmp_path)
+    env = _env(tmp_path, seats=2)
+    cache = repo / ".cache" / "worktrees" / "foo"
+    cache.mkdir(parents=True)
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(DISPATCH),
+            "--unregistered-forced",
+            "--agent",
+            "test-dispatch",
+            "--dispatch-id",
+            "cwd-refuse",
+            "--cwd",
+            str(cache),
+            "--launch-detached",
+            "--tail",
+            str(tmp_path / "cwd-refuse.tail"),
+            "--status-json",
+            str(tmp_path / "cwd-refuse.status.json"),
+            "--",
+            sys.executable,
+            "-c",
+            "print('nope')",
+        ],
+        cwd=str(repo),
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=30,
+    )
+    combined = proc.stdout + proc.stderr
+    assert proc.returncode != 0, combined
+    assert "not a seat" in combined or "refusing" in combined.lower()
+    assert not (cache / ".git").exists()
+    assert not (repo / "worktrees").exists()
+
+
+def test_resume_injects_skip_seat_reset(tmp_path: Path) -> None:
+    import argparse
+    import goalflight_dispatch as D
+
+    worktree = tmp_path / "historical-bt"
+    worktree.mkdir()
+    prompt = tmp_path / "resume.md"
+    prompt.write_text("continue\n", encoding="utf-8")
+    source = {
+        "engine": "grok",
+        "agent": "grok-code",
+        "session_id": "sess",
+        "shape": "bash",
+        "record": {
+            "worker_cwd": str(worktree),
+            "dispatch_argv": [
+                "--agent",
+                "grok-code",
+                "--cwd",
+                str(worktree),
+            ],
+        },
+    }
+    resume_args = argparse.Namespace(
+        dispatch_id="parent-resume",
+        cwd=None,
+        unregistered_forced=True,
+        controller_label=None,
+        controller_pid=None,
+        controller_session_id=None,
+    )
+    argv = D._resume_launch_argv(
+        source,
+        child_dispatch_id="child-resume",
+        prompt_path=prompt,
+        resume_args=resume_args,
+    )
+    assert "--skip-seat-reset" in argv
+    cwd = D._option_value_before_worker_remainder(argv, "--cwd")
+    assert Path(str(cwd)).resolve() == worktree.resolve()

--- a/tests/python/test_drain_launch_serial.py
+++ b/tests/python/test_drain_launch_serial.py
@@ -1607,12 +1607,11 @@ def test_real_worktree_seat_child_does_not_emit_proven_prefix_or_spend_budget(
 
     holder = pool.acquire_worktree_seat(repo, "seat-holder")
     try:
+        monkeypatch.chdir(repo)
         code = D.main(
             [
                 "--agent",
                 "test-dispatch",
-                "--cwd",
-                str(repo),
                 "--worktree",
                 "HEAD",
                 "--unregistered-forced",

--- a/tests/python/test_worktree_dispatch.py
+++ b/tests/python/test_worktree_dispatch.py
@@ -115,8 +115,12 @@ def test_worktree_create_routes_distinct_cwds_and_stale_probe() -> None:
             # `repo` for comparison so the assertion isn't fooled by the /private prefix.
             resolved_repo = repo.resolve()
             assert_true("distinct worktrees", wt_one != wt_two)
-            assert_true("first under managed root", wt_one.parent == resolved_repo / "worktrees")
-            assert_true("second under managed root", wt_two.parent == resolved_repo / "worktrees")
+            ring = resolved_repo / "worktrees" / goalflight_worktree_pool.default_controller_ring_label(
+                None, project_root=resolved_repo
+            )
+            assert_true("first under captive ring", wt_one.parent == ring)
+            assert_true("second under captive ring", wt_two.parent == ring)
+            assert_true("captive seat names", {wt_one.name, wt_two.name} == {"s-1", "s-2"})
             assert_true("first cfg cwd unchanged", args_one.cwd == str(repo))
             assert_true("second cfg cwd unchanged", args_two.cwd == str(repo))
 
@@ -398,7 +402,14 @@ def test_runner_worktree_status_and_capacity_contract() -> None:
             # Worktree path is built from repo.resolve() in the runner (macOS
             # /var/folders → /private/var/folders resolution); compare against
             # the same.
-            worktree_path = repo.resolve() / "worktrees" / "wt-1"
+            worktree_path = (
+                repo.resolve()
+                / "worktrees"
+                / goalflight_worktree_pool.default_controller_ring_label(
+                    None, project_root=repo.resolve()
+                )
+                / "s-1"
+            )
             assert_true("runner complete", payload["state"] == "complete")
             assert_true("status worktree path", status["worktree_path"] == str(worktree_path))
             assert_true("status worker cwd", status["worker_cwd"] == str(worktree_path))
@@ -484,7 +495,14 @@ def test_runner_worktree_create_failure_writes_failed_status() -> None:
             os.environ["GOALFLIGHT_CAPACITY_WAIT_S"] = "0"
             os.environ[goalflight_worktree_pool.WORKTREE_SEATS_ENV] = "1"
             repo = make_repo(root)
-            existing = repo / "worktrees" / "wt-1"
+            existing = (
+                repo
+                / "worktrees"
+                / goalflight_worktree_pool.default_controller_ring_label(
+                    None, project_root=repo
+                )
+                / "s-1"
+            )
             existing.mkdir(parents=True)
             status_path = repo / "existing-status.json"
             args = runner_args(repo, "acp-existing", status_path)

--- a/tests/python/test_worktree_dispatch.py
+++ b/tests/python/test_worktree_dispatch.py
@@ -189,9 +189,12 @@ def test_worktree_leaf_symlink_is_rejected() -> None:
         repo = make_repo(root)
         outside = root / "outside"
         outside.mkdir()
-        managed = repo / "worktrees"
-        managed.mkdir()
-        (managed / "wt-1").symlink_to(outside, target_is_directory=True)
+        label = goalflight_worktree_pool.default_controller_ring_label(
+            None, project_root=repo
+        )
+        managed = repo / "worktrees" / label
+        managed.mkdir(parents=True)
+        (managed / "s-1").symlink_to(outside, target_is_directory=True)
 
         try:
             goalflight_worktree_pool.acquire_worktree_seat(repo, "acp-test-leaf")
@@ -263,19 +266,32 @@ def test_doctor_flags_orphaned_blocking_path() -> None:
 def test_execute_parallel_docs_require_worktree_create() -> None:
     text = (ROOT / "commands" / "execute.md").read_text()
     protocol = (ROOT / "protocols" / "worktrees-parallel.md").read_text()
-    assert_true("parallel uses worktree create", "`--worktree create`" in text)
-    assert_true("parallel threshold documented", "`--parallel N` where `N >= 2`" in text)
-    assert_true("sequential stays root", "Sequential dispatch" in text and "project root" in text)
+    assert_true("isolation is not a mode", "Isolation is not a mode" in text)
+    assert_true(
+        "canonical snippet has no --cwd",
+        "--agent <ready-agent> --prompt-file p.md" in text
+        and "--cwd ." not in text,
+    )
     assert_true("HEAD-only base documented", "committed `HEAD`" in text)
     assert_true("preserve unrelated WIP", "Preserve unrelated WIP." in text)
     assert_true(
         "never move another owner's WIP",
         "Never stash, move, or discard another owner's WIP" in text,
     )
-    assert_true("slot range documented", "`worktrees/wt-1`" in text)
+    assert_true("captive slot range documented", "worktrees/<controller-label>/s-1" in text)
     assert_true("hard ceiling documented", "hard ceiling" in text)
-    assert_true("index exclude documented", "`worktrees/wt-*`" in protocol)
+    assert_true("fuse default documented", "default 24" in text)
+    assert_true("index the captive ring", "Index the captive ring" in protocol)
+    assert_true(
+        "do not exclude captive seats",
+        "Do **not** exclude `worktrees/s-*`" in protocol,
+    )
     assert_true("codedb ignore location documented", "`.codedbignore`" in protocol)
+    assert_true(
+        "protocol forbids sequential-root split",
+        "sequential dispatch" not in protocol.lower()
+        or "stays in the project root" not in protocol,
+    )
 
 
 class FakeProc:

--- a/tests/python/test_worktree_gc.py
+++ b/tests/python/test_worktree_gc.py
@@ -421,7 +421,7 @@ def test_pool_seat_is_never_reclaimed_as_litter(
     lease = goalflight_worktree_pool.acquire_worktree_seat(repo, "register-seat")
     wt = lease.path
     lease.release()
-    assert wt.name == "wt-1"
+    assert wt.name == "s-1"
 
     _done, report = _run(repo)
     entry = _entry(report, wt)

--- a/tests/python/test_worktree_seat_pool.py
+++ b/tests/python/test_worktree_seat_pool.py
@@ -70,7 +70,13 @@ def seat_limit(limit: int):
 
 def pooled_worktrees(repo: Path) -> list[Path]:
     root = repo.resolve() / "worktrees"
-    return sorted(path for path in root.glob("wt-*") if path.is_dir())
+    if not root.is_dir():
+        return []
+    return sorted(
+        path
+        for path in root.rglob("*")
+        if path.is_dir() and goalflight_worktree_pool.is_pool_seat_path(path)
+    )
 
 
 def start_seat_holder(repo: Path, dispatch_id: str) -> tuple[subprocess.Popen[str], Path]:
@@ -107,15 +113,15 @@ def test_hard_ceiling_is_lazy_and_reuses_seats() -> None:
         repo = make_repo(Path(td))
 
         first = goalflight_worktree_pool.acquire_worktree_seat(repo, "dispatch-one")
-        assert_true("first seat name", first.path.name == "wt-1")
-        assert_true("one lazy checkout", [p.name for p in pooled_worktrees(repo)] == ["wt-1"])
+        assert_true("first seat name", first.path.name == "s-1")
+        assert_true("one lazy checkout", [p.name for p in pooled_worktrees(repo)] == ["s-1"])
 
         second = goalflight_worktree_pool.acquire_worktree_seat(repo, "dispatch-two")
-        assert_true("second seat name", second.path.name == "wt-2")
+        assert_true("second seat name", second.path.name == "s-2")
         assert_true("distinct concurrent seats", first.path != second.path)
         assert_true(
             "pool grows with concurrency",
-            [p.name for p in pooled_worktrees(repo)] == ["wt-1", "wt-2"],
+            [p.name for p in pooled_worktrees(repo)] == ["s-1", "s-2"],
         )
 
         try:
@@ -124,15 +130,18 @@ def test_hard_ceiling_is_lazy_and_reuses_seats() -> None:
             message = str(exc)
             assert_true(
                 "ceiling names first occupant",
-                "wt-1" in message and "dispatch-one" in message,
+                "s-1" in message and "dispatch-one" in message,
             )
             assert_true(
                 "ceiling names second occupant",
-                "wt-2" in message and "dispatch-two" in message,
+                "s-2" in message and "dispatch-two" in message,
             )
         else:
             raise AssertionError("third concurrent dispatch exceeded a two-seat ceiling")
-        assert_true("no seat N+1", not (repo.resolve() / "worktrees" / "wt-3").exists())
+        assert_true(
+            "no seat N+1",
+            not any(path.name == "s-3" for path in pooled_worktrees(repo)),
+        )
 
         first.release()
         second.release()
@@ -143,10 +152,13 @@ def test_hard_ceiling_is_lazy_and_reuses_seats() -> None:
             lease = goalflight_worktree_pool.acquire_worktree_seat(
                 repo, f"sequential-{index}"
             )
-            assert_true("sequential reuse chooses existing seat", lease.path.name == "wt-1")
+            assert_true("sequential reuse chooses existing seat", lease.path.name == "s-1")
             lease.release()
             assert_true("sequential count stays bounded", len(pooled_worktrees(repo)) <= 2)
-        assert_true("ceiling remains exact", not (repo.resolve() / "worktrees" / "wt-3").exists())
+        assert_true(
+            "ceiling remains exact",
+            not any(path.name == "s-3" for path in pooled_worktrees(repo)),
+        )
 
 
 def test_process_concurrency_gets_distinct_seats_and_names_all_occupants() -> None:
@@ -161,7 +173,7 @@ def test_process_concurrency_gets_distinct_seats_and_names_all_occupants() -> No
             assert_true("processes receive distinct seats", first_path != second_path)
             assert_true(
                 "process concurrency fills exact range",
-                {first_path.name, second_path.name} == {"wt-1", "wt-2"},
+                {first_path.name, second_path.name} == {"s-1", "s-2"},
             )
             try:
                 goalflight_worktree_pool.acquire_worktree_seat(repo, "process-three")
@@ -169,17 +181,17 @@ def test_process_concurrency_gets_distinct_seats_and_names_all_occupants() -> No
                 detail = str(exc)
                 assert_true(
                     "failure names process one",
-                    "wt-1" in detail and "process-one" in detail,
+                    "s-1" in detail and "process-one" in detail,
                 )
                 assert_true(
                     "failure names process two",
-                    "wt-2" in detail and "process-two" in detail,
+                    "s-2" in detail and "process-two" in detail,
                 )
             else:
                 raise AssertionError("third process exceeded a two-seat ceiling")
             assert_true(
-                "process pressure creates no wt-3",
-                not (repo / "worktrees" / "wt-3").exists(),
+                "process pressure creates no s-3",
+                not any(path.name == "s-3" for path in pooled_worktrees(repo)),
             )
         finally:
             for proc in holders:
@@ -198,7 +210,7 @@ def test_dirty_seat_is_quarantined_then_reset_on_acquire() -> None:
 
         reused = goalflight_worktree_pool.acquire_worktree_seat(repo, "next")
         try:
-            assert_true("same seat reused", reused.path.name == "wt-1")
+            assert_true("same seat reused", reused.path.name == "s-1")
             assert_true(
                 "tracked file reset to base",
                 (reused.path / "tracked.txt").read_text(encoding="utf-8") == "base\n",
@@ -213,7 +225,7 @@ def test_dirty_seat_is_quarantined_then_reset_on_acquire() -> None:
             ).splitlines()
             assert_true("one visible quarantine branch", len(branches) == 1)
             branch = branches[0]
-            assert_true("branch names seat", "wt-1" in branch)
+            assert_true("branch names seat", "s-1" in branch)
             assert_true(
                 "quarantine diff non-empty",
                 bool(git(repo, "diff", "--name-only", f"main..{branch}")),
@@ -254,7 +266,7 @@ def test_sigkill_releases_kernel_lease_without_cleanup() -> None:
         try:
             assert proc.stdout is not None
             held_path = Path(proc.stdout.readline().strip())
-            assert_true("child acquired seat", held_path.name == "wt-1")
+            assert_true("child acquired seat", held_path.name == "s-1")
             try:
                 goalflight_worktree_pool.acquire_worktree_seat(repo, "blocked-worker")
             except goalflight_worktree_pool.WorktreeSeatUnavailable as exc:
@@ -392,8 +404,12 @@ def test_default_seat_count_is_not_a_per_controller_cap() -> None:
         goalflight_worktree_pool.DEFAULT_WORKTREE_SEATS == 24,
     )
     assert_true(
-        "wt-1 basename matches the seat name pattern",
+        "wt-1 basename matches the legacy seat name pattern",
         goalflight_worktree_pool.is_pool_seat_path("/repo/worktrees/wt-1"),
+    )
+    assert_true(
+        "s-1 basename matches the captive seat name pattern",
+        goalflight_worktree_pool.is_pool_seat_path("/repo/worktrees/ctrl/s-1"),
     )
     assert_true(
         "ad-hoc task tree is not a pool seat name",
@@ -425,11 +441,11 @@ def test_registration_ignores_basename_without_a_lock() -> None:
                     lease.path, project_root=repo
                 )
                 assert_true("acquired seat is registered", yes == "yes")
-                assert_true("reason names the seat", "wt-1" in yes_reason)
+                assert_true("reason names the seat", "s-1" in yes_reason)
             finally:
                 lease.release()
             still_yes, _ = goalflight_worktree_pool.registered_pool_seat_verdict(
-                repo / "worktrees" / "wt-1", project_root=repo
+                lease.path, project_root=repo
             )
             assert_true("released seat stays registered", still_yes == "yes")
 
@@ -438,7 +454,7 @@ def test_registration_ignores_basename_without_a_lock() -> None:
             try:
                 unknown, unknown_reason = (
                     goalflight_worktree_pool.registered_pool_seat_verdict(
-                        repo / "worktrees" / "wt-1", project_root=repo
+                        lease.path, project_root=repo
                     )
                 )
             finally:
@@ -453,6 +469,141 @@ def test_registration_ignores_basename_without_a_lock() -> None:
             )
 
 
+def test_notes_survive_acquire_reset_and_result_is_quarantined() -> None:
+    with tempfile.TemporaryDirectory() as td, seat_limit(1):
+        repo = make_repo(Path(td))
+        first = goalflight_worktree_pool.acquire_worktree_seat(repo, "notes-one")
+        notes = first.path / ".goal-flight" / "seat" / "memory.md"
+        notes.parent.mkdir(parents=True)
+        notes.write_text("keep me\n", encoding="utf-8")
+        (first.path / "RESULT.md").write_text("old result\n", encoding="utf-8")
+        first.release()
+
+        reused = goalflight_worktree_pool.acquire_worktree_seat(repo, "notes-two")
+        try:
+            assert_true("same captive seat", reused.path.name == "s-1")
+            assert_true("notes survived reset", notes.is_file())
+            assert_true(
+                "notes content kept",
+                notes.read_text(encoding="utf-8") == "keep me\n",
+            )
+            assert_true("RESULT.md cleared", not (reused.path / "RESULT.md").exists())
+            branches = git(
+                repo,
+                "for-each-ref",
+                "--format=%(refname:short)",
+                "refs/heads/goalflight/quarantine/",
+            ).splitlines()
+            assert_true("quarantine captured RESULT.md", len(branches) == 1)
+            assert_true(
+                "RESULT.md in quarantine",
+                git(repo, "show", f"{branches[0]}:RESULT.md") == "old result",
+            )
+        finally:
+            reused.release()
+
+
+def test_skip_reset_keeps_dirty_product_files() -> None:
+    with tempfile.TemporaryDirectory() as td, seat_limit(1):
+        repo = make_repo(Path(td))
+        first = goalflight_worktree_pool.acquire_worktree_seat(repo, "resume-src")
+        (first.path / "RESULT.md").write_text("in progress\n", encoding="utf-8")
+        path = first.path
+        first.release()
+
+        resumed = goalflight_worktree_pool.acquire_worktree_seat(
+            repo, "resume-dst", reset=False, occupy_path=path
+        )
+        try:
+            assert_true("occupied same seat", resumed.path == path)
+            assert_true(
+                "dirty product survived skip-reset",
+                (path / "RESULT.md").read_text(encoding="utf-8") == "in progress\n",
+            )
+        finally:
+            resumed.release()
+
+
+def test_two_controller_labels_get_separate_rings() -> None:
+    with tempfile.TemporaryDirectory() as td, seat_limit(2):
+        repo = make_repo(Path(td))
+        a = goalflight_worktree_pool.acquire_worktree_seat(
+            repo, "ctrl-a", controller_label="alpha"
+        )
+        b = goalflight_worktree_pool.acquire_worktree_seat(
+            repo, "ctrl-b", controller_label="beta"
+        )
+        try:
+            assert_true("both get s-1", a.path.name == "s-1" and b.path.name == "s-1")
+            assert_true("separate ring directories", a.path.parent != b.path.parent)
+            assert_true("alpha ring", a.path.parent.name == "alpha")
+            assert_true("beta ring", b.path.parent.name == "beta")
+        finally:
+            a.release()
+            b.release()
+
+
+def test_classify_dispatch_cwd_lock() -> None:
+    with tempfile.TemporaryDirectory() as td, seat_limit(1):
+        repo = make_repo(Path(td))
+        lease = goalflight_worktree_pool.acquire_worktree_seat(
+            repo, "cwd-lock", controller_label="alpha"
+        )
+        try:
+            assert_true(
+                "project root is in-place",
+                goalflight_worktree_pool.classify_dispatch_cwd(
+                    repo, project_root=repo, controller_label="alpha"
+                )
+                == "in-place",
+            )
+            assert_true(
+                "own seat is ring-seat",
+                goalflight_worktree_pool.classify_dispatch_cwd(
+                    lease.path, project_root=repo, controller_label="alpha"
+                )
+                == "ring-seat",
+            )
+            other = repo / ".cache" / "worktrees" / "foo"
+            other.mkdir(parents=True)
+            assert_true(
+                "cache tree is refused",
+                goalflight_worktree_pool.classify_dispatch_cwd(
+                    other, project_root=repo, controller_label="alpha"
+                )
+                == "refuse",
+            )
+            foreign = goalflight_worktree_pool.classify_dispatch_cwd(
+                lease.path, project_root=repo, controller_label="beta"
+            )
+            assert_true("other controller seat is refused", foreign == "refuse")
+        finally:
+            lease.release()
+
+
+def test_hwm_stays_after_release() -> None:
+    with tempfile.TemporaryDirectory() as td, seat_limit(4):
+        repo = make_repo(Path(td))
+        first = goalflight_worktree_pool.acquire_worktree_seat(
+            repo, "hwm-a", controller_label="lab"
+        )
+        second = goalflight_worktree_pool.acquire_worktree_seat(
+            repo, "hwm-b", controller_label="lab"
+        )
+        assert_true("grew to two", {first.path.name, second.path.name} == {"s-1", "s-2"})
+        first.release()
+        second.release()
+        third = goalflight_worktree_pool.acquire_worktree_seat(
+            repo, "hwm-c", controller_label="lab"
+        )
+        try:
+            assert_true("reuses existing seat", third.path.name in {"s-1", "s-2"})
+            assert_true("does not mint s-3", not (third.path.parent / "s-3").exists())
+            assert_true("captive pair remains", len(pooled_worktrees(repo)) == 2)
+        finally:
+            third.release()
+
+
 def main() -> None:
     tests = [
         test_hard_ceiling_is_lazy_and_reuses_seats,
@@ -464,6 +615,11 @@ def main() -> None:
         test_parent_release_keeps_inherited_worker_lease_until_worker_dies,
         test_default_seat_count_is_not_a_per_controller_cap,
         test_registration_ignores_basename_without_a_lock,
+        test_notes_survive_acquire_reset_and_result_is_quarantined,
+        test_skip_reset_keeps_dirty_product_files,
+        test_two_controller_labels_get_separate_rings,
+        test_classify_dispatch_cwd_lock,
+        test_hwm_stays_after_release,
     ]
     for test in tests:
         test()

--- a/tests/python/test_worktree_seat_pool.py
+++ b/tests/python/test_worktree_seat_pool.py
@@ -577,6 +577,15 @@ def test_classify_dispatch_cwd_lock() -> None:
                 lease.path, project_root=repo, controller_label="beta"
             )
             assert_true("other controller seat is refused", foreign == "refuse")
+            orphan = Path(td) / "nongit-project"
+            orphan.mkdir()
+            assert_true(
+                "non-git project root is in-place",
+                goalflight_worktree_pool.classify_dispatch_cwd(
+                    orphan, project_root=orphan, controller_label="alpha"
+                )
+                == "in-place",
+            )
         finally:
             lease.release()
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Default `goalflight_dispatch.py --agent <preset> --prompt-file p.md` now acquires a captive seat at `worktrees/<controller-label>/s-N`. Isolation is not a mode.

## Why

Pooled seats existed but were opt-in. The documented command passed `--cwd`, sequential execute stayed in the project root, and `--cwd` to a new directory was the sprawl path (ad-hoc `.cache/worktrees/*`, new codedb project keys per checkout).

## Behavior

- One occupant per seat via the existing kernel flock. Death releases the lock.
- Per-controller rings so two controllers on one repo do not steal each other's warm index and notes.
- Grow to that controller's live high-water mark; never shrink; never `git worktree add` as a fallback.
- `GOALFLIGHT_WORKTREE_SEATS` remains a fuse (default 24), not a fan-out knob.
- `--at <ref>` (alias `--worktree <ref>`) prepares the seat at a git ref.
- `--cwd` is a lock: this controller's existing seat, the project root (`--in-place` or `--cwd` at that project's git toplevel / non-git project identity), or resume's recorded `worker_cwd`. Nested paths under another checkout (`.cache/worktrees/…`, ad-hoc linked worktrees) are refused and never created.
- `resume <id>` does not require `--cwd` and skips acquire-reset so partial work survives.
- `.goal-flight/seat/` notes survive reset; leftover `RESULT.md` / product files still quarantine.
- codedb doctrine: index the captive ring (stable path → same project). Do not exclude `worktrees/s-*`.
- Legacy `worktrees/wt-N` stays registered for GC. Historical `.cache/worktrees/*` trees are not converted.

## Tests

Hermetic coverage for default acquire, sequential reuse, concurrent HWM growth, `--cwd` refuse/in-place (including non-git project roots), resume skip-reset, notes vs product quarantine, fuse exhaustion, and separate controller rings.

### Focused (this branch; isolated `GOALFLIGHT_*` temp dirs, no global `GOALFLIGHT_DISPATCH_DIR`)

All green:

| Command | Result |
|---|---|
| `python3 tests/python/test_worktree_seat_pool.py` | 14 PASS |
| `pytest tests/python/test_dispatch_worktree_pool.py` | 20 passed |
| `pytest tests/python/test_worktree_gc.py` | 19 passed |
| `pytest tests/python/test_dispatch_argv_fidelity.py` | 17 passed |
| `pytest tests/python/test_worktree_dispatch.py` | 10 passed |
| `python3 tests/python/test_dispatch_worktree_occupancy.py` | PASS (skips live ACP) |
| `python3 tests/python/test_dispatch_crash_safe.py` | PASS |
| `pytest tests/python/test_drain_launch_serial.py` | 33 passed |

None of those modules appear in the isolated-suite failure list.

### Full gate `./tests/run.sh`

Same isolation (temp `GOALFLIGHT_JOURNAL_DIR`, `STATE_DIR`, `WAKE_LEDGER`, `MESSAGES_DIR`, `TASK_STORE`, `PIDFILE_DIR`; `GOALFLIGHT_CAPACITY_CONF=/dev/null`; `GOALFLIGHT_DISPATCH_DIR` unset).

**22 passed, 5 skipped, 4 failed** (exit 4). Isolated Python: **211 passed, 34 failed, 5 skipped, 1 flake**. No live `worktrees/` created under the repo.

Gate buckets:

1. `tests/bash/test-goalflight-setup.sh` — `no ready default setup destinations for agent: codex` (env).
2. `tests/bash/test-plugin-manifest.sh` — plugin.json `1.5.1` != `VERSION` `1.6.0` (release-declaration skew on `main`; this PR does not bump skill/plugin version).
3. `tests/bash/test-watch-dispatch-tail.sh` — case-3b `running_quiet` / CPU-busy silence (`92 passed, 2 failed`). Watcher files are unchanged vs `origin/main`; not fixed here.
4. `tests/python` isolated suite — 33 modules + the flake-e2e harness. No `WorktreeCwdRefused` / seat-acquire / `--cwd` lock / resume skip-reset hits. Reproduced on `origin/main` or explained by this environment: missing ACP venv/`acp`/`cursor-agent`, SKILL/plugin `1.5.1` vs `1.6.0`, Python 3.12 `Path.exists()` raising on mode-000, `machine_isolation` import when conftest is copied to a tmp suite, drain tests that mock `subprocess.run` (stdout `blocked_capacity` becomes a fake git root), and unrelated source-scan / liveness / mailbox modules.

**No new captive-ring / default-seat / `--cwd` lock / resume skip-acquire failure on this branch.**

Out of scope: battery-tool-v2, operator-machine GC `--apply`, converting historical ad-hoc trees.

## Remaining risk

- First natural dispatch in a real repo will mint `worktrees/<label>/s-N` and a codedb index for that stable path (intended).
- Drain of a historical argv that omitted `--cwd` binds using the envelope `process_cwd` / `project_root` (intended); do not treat mocked-`subprocess.run` journal errors as a product regression.
- ACP launch path was not exercised here (managed ACP interpreter / `cursor-agent` absent).
- Watcher case-3b remains red on `main` and on this branch.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-29ddad4f-54d9-4e4e-9d24-3215f214ad9b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-29ddad4f-54d9-4e4e-9d24-3215f214ad9b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

