### PR TITLE
Pin skill YAML to 1.6.0 and when-to-use frontmatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ incremented when meaningful skill behaviour changes.
 
 ## [Unreleased]
 
+### Changed
+
+- Skill and command YAML is when-to-use, not a product blurb. Dropped
+  unhonored gstack keys (`tags`, `triggers`, and directory-map `paths`
+  that collide with host file-glob `paths`). Omitted full-kit
+  `allowed-tools` — that field is a Claude pre-grant, not a sandbox.
+  Claude/Cursor dispatch surfaces set `disable-model-invocation: true`.
+  Version declarations agree with `VERSION` 1.6.0 (`SKILL.md` frontmatter
+  and the Codex `plugin.json` pin).
+
 ### Fixed
 
 - `supervise` backlog cap keys on envelope identity, not raw line count.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,39 +1,9 @@
 ---
 name: goal-flight
-version: 1.5.1
-description: "Portable Goal Flight workflow for long-running repo work: planning, dispatch, review, recovery, file-backed resume."
-tags:
-  - orchestration
-  - orchestrator
-  - dispatch
-  - review
-  - handoff
-paths:
-  commands: commands/
-  protocols: protocols/
-  scripts: scripts/
-  adapters: adapters/
-allowed-tools:
-  - Bash
-  - Read
-  - Edit
-  - Write
-  - Glob
-  - Grep
-  - Agent
-  - Skill
-  - AskUserQuestion
-  - TodoWrite
-triggers:
-  - /goal-flight
-  - start a long refactor
-  - begin chunked work
-  - set up orchestrator for unattended run
-  - decompose this plan into goal chunks
-  - resume the goal-flight run
-  - continue the goal queue
-  - recover a dispatched worker
-  - check mail
+version: 1.6.0
+description: "Use when the user invokes /goal-flight or asks for Goal Flight to plan, dispatch, review, recover, or resume a long-running orchestrated repository run from file-backed state."
+when_to_use: "User invoked /goal-flight, or asked to start, resume, or recover a Goal Flight orchestrated run. Not for generic coding or one-off edits."
+disable-model-invocation: true
 ---
 
 > ⚠️ **Read this skill end-to-end, including Worker Routing, State, and Context Discipline** before acting; also read Do Not. The back half carries routing, state, marker, rate-limit, permission, and safety contracts.

--- a/commands/ask-questions.md
+++ b/commands/ask-questions.md
@@ -1,5 +1,7 @@
 ---
-description: "Spawn read-only question-finding workers before unattended work."
+description: "Use when the user invokes /goal-flight ask-questions to spawn read-only Goal Flight workers that surface blocking questions before an unattended run."
+argument-hint: "[--scope area]"
+disable-model-invocation: true
 ---
 
 # ask-questions [--scope <area>]

--- a/commands/bug-sweep.md
+++ b/commands/bug-sweep.md
@@ -1,5 +1,7 @@
 ---
-description: "Run a lane-fill bug-sweep campaign: audit → harvest → consolidate → adversarial verify → grouped fixes."
+description: "Use when the user invokes /goal-flight bug-sweep to run a Goal Flight lane-fill bug-sweep campaign."
+argument-hint: "[--mode milestone|qa|bug-hunt|predicate] [--anchor ref]"
+disable-model-invocation: true
 ---
 
 # bug-sweep [--mode <milestone|qa|bug-hunt|predicate>] [--anchor <ref>]

--- a/commands/build-corpus.md
+++ b/commands/build-corpus.md
@@ -1,5 +1,7 @@
 ---
-description: "Build or refresh the private dispatch-context corpus."
+description: "Use when the user invokes /goal-flight build-corpus to build or refresh the private Goal Flight dispatch-context corpus."
+argument-hint: "[--slice name] [--next-wave N] [--all] [--rebuild]"
+disable-model-invocation: true
 ---
 
 # build-corpus [--slice <name>] [--next-wave [<N>]] [--all] [--rebuild]

--- a/commands/controller-behavior-test.md
+++ b/commands/controller-behavior-test.md
@@ -1,5 +1,7 @@
 ---
-description: "Run scripted orchestrator behavior scenarios (Codex-first bash-tail harness)."
+description: "Use when the user invokes /goal-flight controller-behavior-test to run scripted Goal Flight orchestrator behavior scenarios."
+argument-hint: "[--controller codex] [--scenario doctor-loads]"
+disable-model-invocation: true
 ---
 
 # controller-behavior-test [--controller codex] [--scenario doctor-loads]

--- a/commands/decompose-plan.md
+++ b/commands/decompose-plan.md
@@ -1,5 +1,7 @@
 ---
-description: "Break a plan into verified goal chunks."
+description: "Use when the user invokes /goal-flight decompose-plan to break a plan into verified Goal Flight queue chunks."
+argument-hint: "[plan-file]"
+disable-model-invocation: true
 ---
 
 # decompose-plan [<plan-file>]

--- a/commands/doctor.md
+++ b/commands/doctor.md
@@ -1,5 +1,5 @@
 ---
-description: "Run procedural readiness checks for goal-flight."
+description: "Use when the user invokes /goal-flight doctor to check Goal Flight host and project readiness."
 ---
 
 # doctor

--- a/commands/execute.md
+++ b/commands/execute.md
@@ -1,5 +1,7 @@
 ---
-description: "Execute queued goal chunks with capacity-aware workers."
+description: "Use when the user invokes /goal-flight execute during an active Goal Flight run to dispatch the next queued chunks."
+argument-hint: "[--parallel N]"
+disable-model-invocation: true
 ---
 
 # execute [--parallel <N>]

--- a/commands/goal.md
+++ b/commands/goal.md
@@ -1,5 +1,7 @@
 ---
-description: "Append one compact goal to the active queue."
+description: "Use when the user invokes /goal-flight goal during an active Goal Flight run to append one compact goal to the queue."
+argument-hint: "[SLUG]"
+disable-model-invocation: true
 ---
 
 # goal <SLUG>

--- a/commands/init.md
+++ b/commands/init.md
@@ -1,5 +1,7 @@
 ---
-description: "Initialize goal-flight state for a project."
+description: "Use when the user invokes /goal-flight init to scaffold Goal Flight project state for a long-running orchestrated repository run."
+argument-hint: "[topic]"
+disable-model-invocation: true
 ---
 
 # init <topic>

--- a/commands/migrate.md
+++ b/commands/migrate.md
@@ -1,5 +1,7 @@
 ---
-description: "Preview and import existing markdown task lists into draft task-store items."
+description: "Use when the user invokes /goal-flight migrate to preview and import existing markdown task lists into Goal Flight draft task-store items."
+argument-hint: "[--source glob]"
+disable-model-invocation: true
 ---
 
 # migrate

--- a/commands/register-codex.md
+++ b/commands/register-codex.md
@@ -1,5 +1,7 @@
 ---
-description: "Register a project path as trusted for Codex CLI."
+description: "Use when the user invokes /goal-flight register-codex to register a project path as trusted for Codex CLI."
+argument-hint: "[project-path]"
+disable-model-invocation: true
 ---
 
 # register-codex [<project-path>]

--- a/commands/resume.md
+++ b/commands/resume.md
@@ -1,5 +1,6 @@
 ---
-description: "Resume from git state, status JSON, and dispatch ledger."
+description: "Use when the user invokes /goal-flight resume to rebuild an already-active Goal Flight run from file-backed state."
+disable-model-invocation: true
 ---
 
 # resume

--- a/commands/self-dispatch-test.md
+++ b/commands/self-dispatch-test.md
@@ -1,5 +1,6 @@
 ---
-description: "Nondestructive OpenCode orchestrator self-dispatch verification."
+description: "Use when the user invokes /goal-flight self-dispatch-test to verify the current host can dispatch read-only Goal Flight OpenCode workers to itself."
+disable-model-invocation: true
 ---
 
 # self-dispatch-test

--- a/commands/update.md
+++ b/commands/update.md
@@ -1,3 +1,8 @@
+---
+description: "Use when the user invokes /goal-flight update to refresh the Goal Flight skill checkout and worker CLIs before an unattended run."
+disable-model-invocation: true
+---
+
 # /goal-flight update
 
 Refresh **goal-flight itself** + the worker CLIs it dispatches to. Two

--- a/commands/usage.md
+++ b/commands/usage.md
@@ -1,5 +1,5 @@
 ---
-description: "Show provider headroom and the soonest upcoming reset."
+description: "Use when the user invokes /goal-flight usage to show Goal Flight provider headroom and the soonest upcoming reset."
 ---
 
 # usage

--- a/commands/validate-dispatch.md
+++ b/commands/validate-dispatch.md
@@ -1,5 +1,6 @@
 ---
-description: "Render and validate a dispatch wrapper without launching it."
+description: "Use when the user invokes /goal-flight validate-dispatch to render and check a Goal Flight dispatch wrapper without launching it."
+argument-hint: "[goal-slug]"
 ---
 
 # validate-dispatch [<goal-slug>]

--- a/commands/validate-queue.md
+++ b/commands/validate-queue.md
@@ -1,5 +1,6 @@
 ---
-description: "Schema-check a goal queue file."
+description: "Use when the user invokes /goal-flight validate-queue to schema-check a Goal Flight goal-queue file."
+argument-hint: "[queue-file]"
 ---
 
 # validate-queue [<queue-file>]

--- a/configs/cursor/skills/goal-flight/SKILL.md
+++ b/configs/cursor/skills/goal-flight/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: goal-flight
-description: "Goal Flight orchestration for Cursor: plan, dispatch, review, recover, and resume long-running repository work from file-backed state."
+description: "Use when the user invokes /goal-flight or asks for Goal Flight to plan, dispatch, review, recover, or resume a long-running orchestrated repository run from file-backed state."
+disable-model-invocation: true
 ---
 
 # goal-flight

--- a/configs/grok/skills/goal-flight/SKILL.md
+++ b/configs/grok/skills/goal-flight/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: goal-flight
-description: "Goal Flight orchestration for Grok: plan, dispatch, review, recover, and resume long-running repository work from file-backed state."
+description: "Use when the user invokes /goal-flight or asks for Goal Flight to plan, dispatch, review, recover, or resume a long-running orchestrated repository run from file-backed state."
 ---
 
 # goal-flight

--- a/configs/opencode/skills/goal-flight/SKILL.md
+++ b/configs/opencode/skills/goal-flight/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: goal-flight
-description: "Goal Flight orchestration for OpenCode: plan, dispatch, review, recover, and resume long-running repository work from file-backed state."
+description: "Use when the user invokes /goal-flight or asks for Goal Flight to plan, dispatch, review, recover, or resume a long-running orchestrated repository run from file-backed state."
 ---
 
 # goal-flight

--- a/plugins/goal-flight/.codex-plugin/plugin.json
+++ b/plugins/goal-flight/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "goal-flight",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "Portable goal orchestration for long-running coding work with planning, dispatch, review, recovery, and file-backed handoffs.",
   "skills": "./skills/",
   "interface": {

--- a/plugins/goal-flight/skills/goal-flight-doctor/SKILL.md
+++ b/plugins/goal-flight/skills/goal-flight-doctor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: goal-flight-doctor
-description: "Run goal-flight readiness diagnostics for the current repository."
+description: "Use when the user invokes /goal-flight doctor or asks for Goal Flight readiness diagnostics on the current repository."
 ---
 
 # goal-flight-doctor

--- a/plugins/goal-flight/skills/goal-flight-init/SKILL.md
+++ b/plugins/goal-flight/skills/goal-flight-init/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: goal-flight-init
-description: "Initialize goal-flight project state for a repository task."
+description: "Use when the user invokes /goal-flight init or asks to start a durable Goal Flight run and scaffold project-local state for long-running orchestrated repository work."
 ---
 
 # goal-flight-init

--- a/plugins/goal-flight/skills/goal-flight/SKILL.md
+++ b/plugins/goal-flight/skills/goal-flight/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: goal-flight
-description: "Goal Flight orchestration for Codex: plan, dispatch, review, recover, and resume long-running repository work from file-backed state."
+description: "Use when the user invokes /goal-flight or asks for Goal Flight to plan, dispatch, review, recover, or resume a long-running orchestrated repository run from file-backed state."
 ---
 
 # goal-flight

--- a/tests/python/test_goalflight_procedural.py
+++ b/tests/python/test_goalflight_procedural.py
@@ -421,6 +421,46 @@ def test_installed_skill_drift_allows_claude_link_mode() -> None:
             os.environ["HOME"] = old_home
 
 
+def test_installed_skill_drift_grok_copy_matches_wrapper() -> None:
+    """Doctor pin is the in-repo host wrapper, not root SKILL.md."""
+    old_home = os.environ.get("HOME")
+    try:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            home = root / "home"
+            project = root / "project"
+            skill_root = root / "goal-flight"
+            os.environ["HOME"] = str(home)
+            _write_skill(skill_root / "SKILL.md", "root bible\n")
+            _write_skill(skill_root / "plugins/goal-flight/skills/goal-flight/SKILL.md", "codex skill\n")
+            _write_skill(skill_root / "configs/cursor/skills/goal-flight/SKILL.md", "cursor skill\n")
+            _write_skill(skill_root / "configs/opencode/skills/goal-flight/SKILL.md", "opencode skill\n")
+            _write_skill(skill_root / "configs/grok/skills/goal-flight/SKILL.md", "grok wrapper\n")
+            _write_skill(home / ".grok/skills/goal-flight/SKILL.md", "grok wrapper\n")
+
+            payload = goalflight_doctor.check_installed_skill_drift(skill_root, project)
+            entries = {entry["path"]: entry for entry in payload["entries"]}
+            grok_path = str(home / ".grok/skills/goal-flight/SKILL.md")
+            grok_entry = entries[grok_path]
+            assert_true("grok pin is the in-repo wrapper", grok_entry["source"] == str(skill_root / "configs/grok/skills/goal-flight/SKILL.md"))
+            assert_true("matching grok wrapper is not drift", grok_entry["drift"] is False)
+            assert_true("grok pin is not the root bible", grok_entry["source_hash"] != payload["source_root_hash"])
+
+            _write_skill(home / ".grok/skills/goal-flight/SKILL.md", "root bible\n")
+            stale = goalflight_doctor.check_installed_skill_drift(skill_root, project)
+            stale_entry = {entry["path"]: entry for entry in stale["entries"]}[grok_path]
+            assert_true("stale grok install that matches the bible still drifts", stale_entry["drift"] is True)
+            assert_true(
+                "stale grok pin stays the wrapper",
+                stale_entry["source"] == str(skill_root / "configs/grok/skills/goal-flight/SKILL.md"),
+            )
+    finally:
+        if old_home is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = old_home
+
+
 def test_installed_skill_drift_project_symlink_stays_copy_mode() -> None:
     old_home = os.environ.get("HOME")
     try:
@@ -1714,6 +1754,7 @@ def main() -> None:
         test_doctor_json_shape,
         test_installed_skill_drift_covers_project_local_copy,
         test_installed_skill_drift_allows_claude_link_mode,
+        test_installed_skill_drift_grok_copy_matches_wrapper,
         test_installed_skill_drift_project_symlink_stays_copy_mode,
         test_doctor_target_project_readiness_split,
         test_doctor_package_repo_validates_plugin_manifest,

--- a/tests/python/test_skill_frontmatter.py
+++ b/tests/python/test_skill_frontmatter.py
@@ -1,0 +1,185 @@
+"""Skill and command YAML is when-to-use, version-pinned, and host-legal."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+
+ROOT = Path(__file__).resolve().parents[2]
+
+FORBIDDEN_SKILL_KEYS = ("tags", "triggers", "paths", "allowed-tools")
+FORBIDDEN_PHRASES = (
+    "check mail",
+    "start a long refactor",
+    "start a refactor",
+)
+
+ROOT_SKILL_KEYS = {
+    "name",
+    "version",
+    "description",
+    "when_to_use",
+    "disable-model-invocation",
+}
+
+CURSOR_SKILL_KEYS = {"name", "description", "disable-model-invocation"}
+HOST_SKILL_KEYS = {"name", "description"}
+
+COMMANDS_WITH_ARGS = {
+    "ask-questions.md",
+    "bug-sweep.md",
+    "build-corpus.md",
+    "controller-behavior-test.md",
+    "decompose-plan.md",
+    "execute.md",
+    "goal.md",
+    "init.md",
+    "migrate.md",
+    "register-codex.md",
+    "validate-dispatch.md",
+    "validate-queue.md",
+}
+
+SIDE_EFFECT_COMMANDS = {
+    "ask-questions.md",
+    "bug-sweep.md",
+    "build-corpus.md",
+    "controller-behavior-test.md",
+    "decompose-plan.md",
+    "execute.md",
+    "goal.md",
+    "init.md",
+    "migrate.md",
+    "register-codex.md",
+    "resume.md",
+    "self-dispatch-test.md",
+    "update.md",
+}
+
+SKILL_PAGES = (
+    Path("SKILL.md"),
+    Path("configs/cursor/skills/goal-flight/SKILL.md"),
+    Path("configs/grok/skills/goal-flight/SKILL.md"),
+    Path("configs/opencode/skills/goal-flight/SKILL.md"),
+    Path("plugins/goal-flight/skills/goal-flight/SKILL.md"),
+    Path("plugins/goal-flight/skills/goal-flight-init/SKILL.md"),
+    Path("plugins/goal-flight/skills/goal-flight-doctor/SKILL.md"),
+)
+
+
+def _expected_version() -> str:
+    return (ROOT / "VERSION").read_text().strip()
+
+
+def _split_frontmatter(text: str) -> tuple[str, str]:
+    assert text.startswith("---\n"), "missing opening frontmatter"
+    close = text.find("\n---\n", 4)
+    assert close != -1, "missing closing frontmatter"
+    return text[4:close], text[close + 5 :]
+
+
+def _parse_frontmatter(block: str) -> dict[str, str]:
+    data: dict[str, str] = {}
+    for raw in block.splitlines():
+        line = raw.rstrip()
+        if not line or line.startswith(" ") or line.startswith("-"):
+            raise AssertionError(f"nested or list YAML is not allowed in skill/command frontmatter: {line!r}")
+        if ":" not in line:
+            raise AssertionError(f"frontmatter line has no key: {line!r}")
+        key, value = line.split(":", 1)
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        assert key, f"empty frontmatter key in {line!r}"
+        data[key] = value
+    return data
+
+
+def _load(rel: Path) -> tuple[dict[str, str], str]:
+    text = (ROOT / rel).read_text()
+    block, body = _split_frontmatter(text)
+    return _parse_frontmatter(block), body
+
+
+def _assert_named_goal_flight(rel: Path, text: str) -> None:
+    lowered = text.lower()
+    for phrase in FORBIDDEN_PHRASES:
+        assert phrase not in lowered, f"{rel}: frontmatter must not include {phrase!r}"
+    assert "goal flight" in lowered or "/goal-flight" in lowered, (
+        f"{rel}: text must name Goal Flight or /goal-flight"
+    )
+
+
+def _assert_when_to_use(rel: Path, description: str) -> None:
+    _assert_named_goal_flight(rel, description)
+    assert "use when" in description.lower(), f"{rel}: description must be when-to-use, not a product blurb"
+
+
+def test_root_skill_frontmatter_is_when_to_use_and_version_pinned() -> None:
+    data, body = _load(Path("SKILL.md"))
+    assert set(data) == ROOT_SKILL_KEYS
+    assert data["name"] == "goal-flight"
+    assert data["version"] == _expected_version()
+    assert data["disable-model-invocation"] == "true"
+    _assert_when_to_use(Path("SKILL.md"), data["description"])
+    _assert_named_goal_flight(Path("SKILL.md"), data["when_to_use"])
+    assert body.lstrip().startswith("> ⚠️"), "root SKILL.md body must stay intact after frontmatter"
+
+
+def test_host_and_plugin_skill_pages_are_when_to_use() -> None:
+    for rel in SKILL_PAGES:
+        if not (ROOT / rel).is_file():
+            continue
+        data, _body = _load(rel)
+        for key in FORBIDDEN_SKILL_KEYS:
+            assert key not in data, f"{rel}: drop unhonored key {key}"
+        _assert_when_to_use(rel, data["description"])
+        assert data["name"]
+        if rel == Path("SKILL.md"):
+            continue
+        if rel == Path("configs/cursor/skills/goal-flight/SKILL.md"):
+            assert set(data) == CURSOR_SKILL_KEYS
+            assert data["disable-model-invocation"] == "true"
+        else:
+            assert set(data) == HOST_SKILL_KEYS
+
+
+def test_optional_grok_bot_wrapper_uses_same_frontmatter_contract() -> None:
+    rel = Path("configs/grok-bot/skills/goal-flight/SKILL.md")
+    if not (ROOT / rel).is_file():
+        return
+    data, _body = _load(rel)
+    for key in FORBIDDEN_SKILL_KEYS:
+        assert key not in data, f"{rel}: drop unhonored key {key}"
+    _assert_when_to_use(rel, data["description"])
+    assert data["name"] == "goal-flight"
+
+
+def test_command_pages_have_when_to_use_frontmatter() -> None:
+    commands = sorted((ROOT / "commands").glob("*.md"))
+    assert commands, "commands/ is empty"
+    for path in commands:
+        rel = path.relative_to(ROOT)
+        data, _body = _load(rel)
+        assert "description" in data, f"{rel}: missing description"
+        _assert_when_to_use(rel, data["description"])
+        if path.name in COMMANDS_WITH_ARGS:
+            assert data.get("argument-hint"), f"{rel}: argument-hint required"
+        if path.name in SIDE_EFFECT_COMMANDS:
+            assert data.get("disable-model-invocation") == "true", (
+                f"{rel}: side-effect command must not auto-invoke"
+            )
+        if path.name == "execute.md":
+            assert data.get("disable-model-invocation") == "true"
+
+
+def test_doctor_pin_reads_host_wrapper_not_root_bible() -> None:
+    text = (ROOT / "scripts/goalflight_doctor.py").read_text()
+    assert 'cursor_source = skill_root / "configs/cursor/skills/goal-flight/SKILL.md"' in text
+    assert 'grok_source = skill_root / "configs/grok/skills/goal-flight/SKILL.md"' in text
+    assert 'opencode_source = skill_root / "configs/opencode/skills/goal-flight/SKILL.md"' in text
+    grok_bot = ROOT / "configs/grok-bot/skills/goal-flight/SKILL.md"
+    if grok_bot.is_file():
+        assert (
+            'grok_bot_source = skill_root / "configs/grok-bot/skills/goal-flight/SKILL.md"'
+            in text
+        ), "grok-bot doctor pin must hash the in-repo wrapper"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Skill and command YAML was a product blurb with cargo-cult gstack keys, and the version pin still said 1.5.1 after the 1.6.0 release. This branch starts from current `main` and does not stack on PRs #3–#7.

## What was on disk

- Root `SKILL.md` YAML had `version: 1.5.1`, slogan `description`, `tags`, directory-map `paths:`, a full-kit `allowed-tools` list, and `triggers` including “check mail” / “start a long refactor”.
- `plugins/goal-flight/.codex-plugin/plugin.json` was still `1.5.1`. `.claude-plugin/plugin.json` and `VERSION` were already `1.6.0`. There is no `SKILL.yaml` file; the pin is the `SKILL.md` frontmatter `version:` line that `test_version_agreement.py` and `_skill_version()` read.
- Host wrappers used slogan descriptions. `commands/update.md` had no frontmatter. Other `commands/*.md` descriptions were what-not-when and skipped `argument-hint`.
- Grok-bot is **not on main** (that is PR #3). Doctor on main already hashes each installed host skill against that host’s in-repo wrapper (`configs/grok/...`, `configs/cursor/...`, etc.), not root `SKILL.md`. A matching grok wrapper copy is not drift; a copy that matches the bible still is.

## What changed

- Root `SKILL.md` frontmatter is `name` + `version: 1.6.0` + when-to-use `description` + Claude `when_to_use` + `disable-model-invocation: true`. Body, Hard Invariants, and controller behaviours are untouched (body bytes match `main`).
- Dropped `tags`, `triggers`, and directory-map `paths` (that key is a host file-glob). Omitted full-kit `allowed-tools` (Claude pre-grant, not a sandbox).
- Cursor wrapper also sets `disable-model-invocation: true`. Codex/Grok/OpenCode wrappers get when-to-use descriptions only.
- Every `commands/*.md` page now has a when-to-use `description`. Commands that take args get `argument-hint`. Dispatch/mutate commands, including `execute`, set `disable-model-invocation: true`.
- Codex `plugin.json` version is `1.6.0`.

## Tests run (hermetic)

Passed:

- `tests/python/test_version_agreement.py` (4)
- `tests/python/test_skill_frontmatter.py` (5)
- `tests/bash/test-plugin-manifest.sh`
- doctor JSON shape + installed skill drift cases in `test_goalflight_procedural.py`, including the new grok wrapper-match / stale-bible-is-drift case
- `test_skill_md_structural_invariants`

Pre-existing on `main` (SKILL.md body unchanged): Golden Master gap `dispatch-cli-worker-via-one-crash-safe-command`. No ACP venv required for this slice.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-beaeacc9-1421-4456-a26b-c0e1a00f61aa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-beaeacc9-1421-4456-a26b-c0e1a00f61aa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

