### PR TITLE
Fold grok-bot slash verbs into the host wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,11 @@ incremented when meaningful skill behaviour changes.
   `configs/grok-bot/skills/goal-flight/SKILL.md`, adapter
   `adapters/grok-bot.json` (distinct from Grok CLI `adapters/grok.json`),
   and `./install.sh grok-bot` copying the wrapper into the Grok Bot
-  workflows library. Grok Bot Executors are a first-class host delegate
+  workflows library. That wrapper is the `/goal-flight` install pin:
+  verbs `usage`, `connected`, `status`, `doctor`, and controller
+  `resume` (not `goalflight_dispatch.py resume`). Bare `/goal-flight`
+  lists them, then runs `status`. CLIs run local-exec on the user's
+  registered computer. Grok Bot Executors are a first-class host delegate
   lane on this port (not Claude's last-resort Host Agent rule); kimi3
   reviews go through `--agent moonshot`. Wake is exit-as-wake: a tracked
   `goalflight_grok_bot_listen.py --report-pending --timeout-s 900` on the

--- a/configs/grok-bot/skills/goal-flight/SKILL.md
+++ b/configs/grok-bot/skills/goal-flight/SKILL.md
@@ -1,12 +1,15 @@
 ---
 name: goal-flight
-description: "Goal Flight orchestration for Grok Bot: plan, dispatch, review, recover, and resume long-running repository work from file-backed state."
+version: 1.6.0
+description: "Use when the user invokes /goal-flight or asks for long-running grok-bot Goal Flight orchestration: plan, dispatch, review, recover, or resume from file-backed state."
+disable-model-invocation: true
 ---
 
 # goal-flight
 
-Use this skill when a repository task needs durable planning, resumable work,
-worker dispatch, review flights, or handoff notes that survive context loss.
+Use this skill when the user invokes `/goal-flight` or asks for long-running
+grok-bot Goal Flight orchestration: durable planning, resumable work, worker
+dispatch, review flights, or handoff notes that survive context loss.
 
 Grok Bot is a host projection over the portable Goal Flight core. It is not a
 rewrite of that core and it does not replace the Grok CLI adapter
@@ -31,11 +34,89 @@ rule cannot live only in compacted chat or a summarized SKILL.md.
 
 ## Skill pin
 
-Live controllers load the detached pin at `~/.goal-flight/skill/` (or
-`$GOALFLIGHT_ROOT`), not a live source checkout and not a clone on the Grok Bot
-box. Run scripts from that pin (`$GOALFLIGHT_ROOT/scripts` or
-`~/.goal-flight/skill/scripts`). Doctor warns when an installed wrapper copy
-has drifted from that pin; resync with `./install.sh grok-bot`.
+Live controllers load the detached pin at `$GOALFLIGHT_ROOT` or
+`~/.goal-flight/skill/`, not a live source checkout and not a clone on the
+Grok Bot box. Run scripts from that pin (`$GOALFLIGHT_ROOT/scripts` or
+`~/.goal-flight/skill/scripts`). The project tree is
+`$GOALFLIGHT_PROJECT_ROOT`, a named checkout, or the live controller
+project — pass `--project-root` when the cwd is not that tree. Doctor
+warns when an installed wrapper copy has drifted from this file; resync
+with `./install.sh grok-bot`.
+
+## Slash commands
+
+This file is the `/goal-flight` skill. Do not invent a second skill name.
+Bare `/goal-flight` lists the verbs below, then runs `status`.
+
+| Verb | Does |
+|---|---|
+| `usage` | Provider headroom: `goalflight_usage.py` |
+| `connected` | Fleet roster: `goalflight_controllers.py`; fallback `goalflight_session_status.py --list-controllers` |
+| `status` | `goalflight_status.py` plus `goalflight_session_status.py --text` |
+| `doctor` | `goalflight_doctor.py --project-root <project>` |
+| `resume` | Controller resume (`commands/resume.md`). Never `goalflight_dispatch.py resume`. |
+
+Run every CLI on the user's registered computer (local-exec / `machineId`).
+Never clone the repository onto the Grok Bot computer.
+
+Do not steal a live lease. Do not drain another controller's mail. Do not
+run bare `goalflight_task.py next` on a lane you do not own.
+
+### `usage`
+
+```shell
+python3 <skill-root>/scripts/goalflight_usage.py
+```
+
+### `connected`
+
+```shell
+python3 <skill-root>/scripts/goalflight_controllers.py
+```
+
+If that script is absent from the pin, fall back to:
+
+```shell
+python3 <skill-root>/scripts/goalflight_session_status.py --list-controllers
+```
+
+### `status`
+
+```shell
+python3 <skill-root>/scripts/goalflight_status.py --project-root <project>
+python3 <skill-root>/scripts/goalflight_session_status.py --project-root <project> --text
+```
+
+### `doctor`
+
+```shell
+python3 <skill-root>/scripts/goalflight_doctor.py --project-root <project>
+```
+
+Set `GOALFLIGHT_GROK_BOT_WORKFLOWS` when running doctor off-box so
+`installed_skill_drift` can hash the installed wrapper against this file.
+
+### `resume` (controller, not dispatch)
+
+Restart this Goal Flight controller session inside Grok Bot. Follow
+`commands/resume.md` with the grok-bot wake substitution. This verb is
+**not** `goalflight_dispatch.py resume`.
+
+1. **STEP 0.** Disk-read repository `SKILL.md` Hard Invariants and quote
+   them. If you cannot, you are stale: reload this wrapper plus the bible
+   before acting.
+2. Auto-claim / renew this controller's lease. If the label is held,
+   prove the holder is dead (`kill -0`) or a sibling of this launch
+   before `--takeover`. Ask the owner only when the holder is alive and
+   rooted in a different session. Never steal a live foreign lease.
+3. **Skip** `commands/resume.md` STEP 1.5 (`supervise`). Arm the wake on
+   the user's Mac: prefer `goalflight_grok_bot_listen.py` when that
+   helper is on the skill pin; else
+   `goalflight_messages.py listen --report-pending --timeout-s 900
+   --listener-slots 4`.
+4. Store baseline (`goalflight_status.py` + `goalflight_task.py list`),
+   read newest RESUME-NOTES, then `goalflight_task.py next` only for a
+   lane this controller owns.
 
 ## Operating Rules
 

--- a/docs/hosts/grok-bot.md
+++ b/docs/hosts/grok-bot.md
@@ -64,6 +64,12 @@ acting) → repository `SKILL.md` → `protocols/guidance-extended.md` by
 default (non-frontier) → newest `docs-private/RESUME-NOTES-*.md` when
 resuming.
 
+`/goal-flight` on this host is that installed wrapper. Verbs: `usage`,
+`connected`, `status`, `doctor`, `resume` (controller resume, not
+`goalflight_dispatch.py resume`). Bare `/goal-flight` lists them, then
+runs `status`. The local-exec contract and verb CLIs live in the
+wrapper; this note does not invent a second skill name.
+
 - Facts come from `goalflight_status.py`, `goalflight_task.py list/next`, and
   doctor. Conversation is not the backlog.
 - Controller label is `goalflight-grokbot`. Stamp it on every dispatch.

--- a/tests/bash/test-install-grok-bot.sh
+++ b/tests/bash/test-install-grok-bot.sh
@@ -468,4 +468,77 @@ if mod._grok_bot_mac_default_warn(
 PY
 echo "test13 pass: grok-bot helper defaults, Mac install caveat, and dispatch stamp"
 
+# Slash-verb pin: the installed wrapper is the /goal-flight skill.
+# Do not grow a parallel grok-bot pytest suite here.
+wrapper="$REPO_ROOT/configs/grok-bot/skills/goal-flight/SKILL.md"
+head_block="$(sed -n '1,8p' "$wrapper")"
+printf '%s\n' "$head_block" | grep -q 'version: 1.6.0' \
+  || fail "wrapper frontmatter must pin version 1.6.0 when VERSION is 1.6.0"
+printf '%s\n' "$head_block" | grep -q '/goal-flight' \
+  || fail "wrapper description must name /goal-flight"
+printf '%s\n' "$head_block" | grep -qi 'long-running grok-bot' \
+  || fail "wrapper description must name long-running grok-bot orchestration"
+printf '%s\n' "$head_block" | grep -qi 'Use when' \
+  || fail "wrapper description must be when-to-use, not a product blurb"
+grep -q 'disable-model-invocation: true' "$wrapper" \
+  || fail "wrapper must set disable-model-invocation: true"
+grep -q '## Slash commands' "$wrapper" \
+  || fail "wrapper must fold the /goal-flight slash verbs"
+for verb in usage connected status doctor resume; do
+  grep -q "\`$verb\`" "$wrapper" \
+    || fail "wrapper slash table must name $verb"
+done
+grep -q 'lists the verbs below, then runs `status`' "$wrapper" \
+  || fail "bare /goal-flight must list verbs then run status"
+grep -q 'goalflight_usage.py' "$wrapper" \
+  || fail "usage must call goalflight_usage.py"
+grep -q 'goalflight_controllers.py' "$wrapper" \
+  || fail "connected must call goalflight_controllers.py"
+grep -q -- '--list-controllers' "$wrapper" \
+  || fail "connected fallback must be session_status --list-controllers"
+grep -q 'goalflight_status.py' "$wrapper" \
+  || fail "status must call goalflight_status.py"
+grep -E 'goalflight_session_status.py.*--text' "$wrapper" >/dev/null \
+  || fail "status must include session_status --text"
+grep -q 'goalflight_doctor.py --project-root' "$wrapper" \
+  || fail "doctor must call goalflight_doctor.py --project-root"
+grep -q 'local-exec' "$wrapper" \
+  || fail "slash contract must require local-exec on the registered computer"
+grep -q 'GOALFLIGHT_PROJECT_ROOT' "$wrapper" \
+  || fail "wrapper must name GOALFLIGHT_PROJECT_ROOT as the project pin"
+grep -q 'Do not steal a live lease' "$wrapper" \
+  || fail "slash contract must forbid stealing a live lease"
+grep -q 'Do not drain another controller' "$wrapper" \
+  || fail "slash contract must forbid draining another controller's mail"
+grep -q 'lane you do not own' "$wrapper" \
+  || fail "slash contract must forbid bare next on an unowned lane"
+if grep -q 'goalflight_dispatch.py resume' "$wrapper"; then
+  grep -E 'Never `goalflight_dispatch.py resume`|not `goalflight_dispatch.py resume`|Never conflate' "$wrapper" >/dev/null \
+    || fail "wrapper must refuse dispatch resume for the slash resume verb"
+else
+  fail "wrapper must name goalflight_dispatch.py resume only to refuse it"
+fi
+grep -q -- '--takeover' "$wrapper" \
+  || fail "controller resume must prove holder dead/sibling before --takeover"
+grep -q -- '--listener-slots 4' "$wrapper" \
+  || fail "resume fallback listen must use --listener-slots 4"
+grep -q 'goalflight_grok_bot_listen.py' "$wrapper" \
+  || fail "resume must prefer goalflight_grok_bot_listen.py when present"
+# Re-install after the wrapper edit path: copy still matches source hash.
+slash_root="$TMP_ROOT/slash-workflows"
+slash_out="$(bash "$REPO_ROOT/install.sh" grok-bot "$slash_root" --addons '' 2>&1)"
+printf '%s\n' "$slash_out" | grep -q '^APPLY ' \
+  || fail "install.sh grok-bot must still apply after slash fold"
+[ -f "$slash_root/goal-flight/SKILL.md" ] \
+  || fail "install.sh grok-bot did not write the unified wrapper"
+src_hash="$(python3 -c "import hashlib, pathlib, sys; print(hashlib.sha256(pathlib.Path(sys.argv[1]).read_bytes()).hexdigest())" "$wrapper")"
+dst_hash="$(python3 -c "import hashlib, pathlib, sys; print(hashlib.sha256(pathlib.Path(sys.argv[1]).read_bytes()).hexdigest())" "$slash_root/goal-flight/SKILL.md")"
+[ "$src_hash" = "$dst_hash" ] \
+  || fail "installed grok-bot skill hash must match configs/grok-bot wrapper"
+grep -q '## Slash commands' "$slash_root/goal-flight/SKILL.md" \
+  || fail "installed wrapper must include the folded slash verbs"
+grep -q 'first-class' "$slash_root/goal-flight/SKILL.md" \
+  || fail "installed wrapper must still carry the host contract"
+echo "test14 pass: unified wrapper is the /goal-flight pin; install hash matches"
+
 echo "goal-flight grok-bot host install tests passed"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The Grok Bot install pin is one file: `configs/grok-bot/skills/goal-flight/SKILL.md`. `./install.sh grok-bot` copies that file into the workflows library. Doctor already hashes the installed copy against this wrapper.

This PR folds the out-of-repo `/goal-flight` slash subset into that wrapper. It does not restack PR #3 and does not rewrite core `SKILL.md` / Hard Invariants.

## What installing grok-bot now produces

The installed skill still has the host contract from #3 (bible on disk, Executors as a lane, journal mail, 15-min listen, no mailman, skip supervise, quote-check Hard Invariants), plus these verbs:

| Verb | Action |
|---|---|
| `usage` | `goalflight_usage.py` |
| `connected` | `goalflight_controllers.py`, fallback `session_status --list-controllers` |
| `status` | `goalflight_status.py` + `session_status --text` |
| `doctor` | `goalflight_doctor.py --project-root` |
| `resume` | Controller resume (`commands/resume.md`). **Not** `goalflight_dispatch.py resume`. |

Bare `/goal-flight` lists those verbs, then runs `status`.

## Slash contract (folded, not a second skill)

- Every CLI runs on the user's registered computer (local-exec / `machineId`). Do not clone onto the Grok Bot box.
- Skill pin: `$GOALFLIGHT_ROOT` or `~/.goal-flight/skill`. Project: `$GOALFLIGHT_PROJECT_ROOT`, a named checkout, or the live controller project.
- Do not steal a live lease. Do not drain another controller's mail. Do not run bare `next` on a lane you do not own.
- `resume`: STEP 0 quote Hard Invariants; prove holder dead/sibling before `--takeover`; wake with `goalflight_grok_bot_listen.py` if present, else `listen --report-pending --timeout-s 900 --listener-slots 4`.
- Frontmatter is when-to-use (`/goal-flight` and long-running grok-bot orchestration), `version: 1.6.0` (matches `VERSION`), and `disable-model-invocation: true`.

## Out of scope

- No parallel grok-bot pytest/bash suite. Only `tests/bash/test-install-grok-bot.sh` grew a hash/install pin check (test14).
- No webhook wake, `post --from`, or `gf` rename.
- No `battery-*` edits. No merge of #3–#8.

## Test plan

- `bash tests/bash/test-install-grok-bot.sh` (existing grok-bot install coverage plus the unified-wrapper hash check)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f03141c-33dc-4e9d-b4f3-f191ee7f77e0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f03141c-33dc-4e9d-b4f3-f191ee7f77e0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

