### PR TITLE
Durable at-least-once wake webhook doorbell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,13 +72,18 @@ incremented when meaningful skill behaviour changes.
 
 ### Added
 
-- Optional outbound wake webhook on listen-visible controller mail/wake
-  harvest. `GOALFLIGHT_WAKE_WEBHOOK_URL` / `GOALFLIGHT_WAKE_WEBHOOK_SECRET`
-  (or `~/.goal-flight/wake-webhook.json`) POST a small JSON nudge
-  (`kind`, `controller_label`, `project_root`, `dispatch_id`, `event_type`)
-  after journal delivery projection commits. Unset URL means zero HTTP.
-  POST failure is logged and ignored; the journal write already happened.
-  Complements exit-as-wake `listen` for Grok Bot local-exec; see
+- Durable at-least-once wake webhook on listen-visible harvest
+  (`Journal.mark_delivery_projected`, the same projection `listen` waits
+  on). A configured URL enqueues a journal `wake_webhook_outbox` row in
+  the same transaction as projection; after commit a sender POSTs until
+  HTTP 2xx or the controller has advanced past / withdrawn the event.
+  Bounded backoff. Later harvests on that same projection path retry
+  due rows (no parallel daemon; listen is not blocked on HTTP). POST
+  failure never rolls back the journal. Unset URL means zero HTTP and
+  no enqueue; doctor warns when a Grok Bot host is in use without a
+  URL, or when a configured URL has undelivered outbox rows. Payload
+  stays the tiny nudge (`kind`, `controller_label`, `project_root`,
+  `dispatch_id`, `event_type`). Complements exit-as-wake `listen`; see
   `docs/hosts/grok-bot.md`.
 - **Grok Bot host port.** Controller-only wrapper at
   `configs/grok-bot/skills/goal-flight/SKILL.md`, adapter

--- a/configs/grok-bot/skills/goal-flight/SKILL.md
+++ b/configs/grok-bot/skills/goal-flight/SKILL.md
@@ -133,26 +133,31 @@ Restart this Goal Flight controller session inside Grok Bot. Follow
   package below.
 - Claim controller label `goalflight-grokbot` and stamp that claimed label
   on every `goalflight_dispatch.py` launch. Never steal a live lease.
-- Wake on worker terminals (`!COMPLETE` is the success marker) through the
-  existing journal doorbell. Canonical arm is one tracked
+- Wake on worker terminals (`!COMPLETE` is the success marker) through two
+  independent doorbells: portable `listen` (exit-as-wake) and the optional
+  outbound wake webhook. The journal on the laptop stays the inbox; mail
+  bodies never leave it. Canonical listen arm is one tracked
   `goalflight_grok_bot_listen.py --report-pending --timeout-s 900
   --controller-label goalflight-grokbot` on the user's Mac (that helper
-  wraps `listen --report-pending` and prints the quote-check banner). The
-  900s quiet timeout is this host's frontier ping (anti-stall), not
-  Claude's 120s follow-stream heartbeat. Optional full pool (depth 4):
-  900s on one slot only; others `--timeout-s 0`. Every ring or timeout is
-  a mini-resume: drain if it rang, flush RESUME-NOTES (`state-handoff.md`
-  Before compact or sleep), quote-check Hard Invariants from disk, re-arm,
-  `goalflight_task.py next`. Never detach.
+  wraps `listen --report-pending` and prints the quote-check banner). Also
+  configure `GOALFLIGHT_WAKE_WEBHOOK_URL` (`docs/hosts/grok-bot.md`) so a
+  dropped local-exec session does not leave wakes dead. Deafness is both
+  listen unarmed and webhook failing. The 900s quiet timeout is this
+  host's frontier ping (anti-stall), not Claude's 120s follow-stream
+  heartbeat. Optional full pool (depth 4): 900s on one slot only; others
+  `--timeout-s 0`. Every ring or timeout is a mini-resume: drain if it
+  rang, flush RESUME-NOTES (`state-handoff.md` Before compact or sleep),
+  quote-check Hard Invariants from disk, re-arm, `goalflight_task.py next`.
+  Never detach.
   Do not invent a second event bus, a Settings monitor widget, a compact
   UI, a context-consumption meter, or a Grok Bot-native mail transport.
   Do not port Claude PostToolUse / SessionStart hooks. Do not arm
   unbounded `supervise` as a background shell. Missed wake is latency:
   resume still pulls status, task next, and `relay --new`. The operator
-  is not the compaction mailman. The one operator wake-hygiene job is
-  re-arming listen doorbells after a host update or token-pause, surfaced
-  as roster `wake unarmed` — not a second reminder channel. See
-  Compaction and Operator role in `docs/hosts/grok-bot.md`.
+  is not the compaction mailman. Operator wake-hygiene is re-arming
+  listen and keeping the webhook URL healthy, surfaced as roster
+  `wake unarmed` / doctor `wake webhook doorbell` — not a second reminder
+  channel. See Compaction and Operator role in `docs/hosts/grok-bot.md`.
 
 ## Dispatch and workers
 

--- a/configs/grok/skills/goal-flight/SKILL.md
+++ b/configs/grok/skills/goal-flight/SKILL.md
@@ -54,8 +54,9 @@ Grok setup installs this personal skill when a Grok orchestrator surface is
 selected. Worker execution remains through `grok agent stdio` under the Goal
 Flight ACP runner.
 
-Grok Bot controllers that arm `listen` through Mac local-exec can add an
-optional outbound wake webhook (`docs/hosts/grok-bot.md`) so a dropped
+Grok Bot controllers that arm `listen` through Mac local-exec should also
+configure the outbound wake webhook (`docs/hosts/grok-bot.md`) so a dropped
 local-exec session does not leave doorbells dead while the journal still
-receives mail. The webhook nudge complements exit-as-wake `listen`; it does
-not replace `listen` when local-exec is up.
+receives mail. `listen` and the webhook are independent alternative doorbells;
+the journal stays the inbox. Deafness is both listen unarmed and webhook
+failing. The webhook does not replace `listen` when local-exec is up.

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ root.
 | [architecture.md](architecture.md) | Portable core, runtime scripts, capacity, and validation boundaries |
 | [fleet.md](fleet.md) | Multi-node SSH fleet: bootstrap, dispatch, watch, reconcile |
 | [hosts/cursor.md](hosts/cursor.md) | Cursor install, MCP, and project-local setup |
-| [hosts/grok-bot.md](hosts/grok-bot.md) | Grok Bot controller wrapper, workflows-library install, wake path, and optional outbound wake-webhook nudge |
+| [hosts/grok-bot.md](hosts/grok-bot.md) | Grok Bot controller wrapper, workflows-library install, and dual doorbell (listen + durable wake-webhook) |
 | [hosts/linux.md](hosts/linux.md) | Linux/WSL dispatch baseline, OS sandbox scope, and filesystem caveats |
 | [hosts/opencode.md](hosts/opencode.md) | OpenCode install, skills, MCP, and bash-tail workers |
 

--- a/docs/hosts/grok-bot.md
+++ b/docs/hosts/grok-bot.md
@@ -358,15 +358,49 @@ Mac (`local-exec`). When that session drops, doorbells die even though workers
 still write the journal. Delivery is not lost — the controller only loses
 promptness until something else wakes it.
 
+## Dual doorbell
+
+Two independent planes, both required for promptness on this host:
+
+1. **Inbox / truth** = the journal on the laptop. Mail bodies, task tables, and
+   secrets never leave that store. `relay` / `advance` are how the controller
+   reads. The operator is not the mailman.
+2. **Wake** = how a host without a persistent stdout Monitor gets a turn.
+   Portable `listen` (exit-as-wake) and the outbound webhook are *independent*
+   alternative doorbells. Claude keeps `supervise` on Monitor; Grok Bot keeps
+   both `listen` and this webhook.
+
+Either doorbell may fire; both may fire. Duplicate wakes are OK — the
+controller peeks the journal and stays quiet if nothing is pending. Missing a
+wake is not OK.
+
+**Deafness** is both `listen` unarmed *and* the webhook failing (or unconfigured).
+Re-arm listen and fix the webhook URL. Do not ask the operator to paste mail
+or to tell another session to check mail.
+
 ## Optional outbound wake webhook
 
-An operator-configured HTTP POST can nudge an external Grok Bot webhook
-routine when a controller-addressed waking event becomes listen-visible
-(the existing journal delivery projection, not a second inbox).
+An operator-configured HTTP POST nudges an external Grok Bot webhook routine
+when a controller-addressed waking event becomes listen-visible (the existing
+journal delivery projection — `Journal.mark_delivery_projected` — not a second
+inbox).
 
 This complements exit-as-wake `listen`. It does **not** replace `listen` when
 local-exec is up, and it is not a Grok Bot-native mail transport. The journal
 remains durable truth; the POST carries no message body.
+
+A configured URL enqueues a journal `wake_webhook_outbox` row in the same
+transaction as that projection. After commit, a sender POSTs due rows.
+Failed POSTs use bounded backoff and never roll back the journal write.
+The next listen-visible harvest (the same `mark_delivery_projected` path)
+retries due rows — there is no parallel daemon, so the doorbells stay
+independent. Listen is not blocked on HTTP. Unset URL means zero HTTP and
+no enqueue (a later-configured host does not inherit historical wakes).
+Doctor warns when this host is in use and the URL is missing, or when a
+configured URL has undelivered outbox rows.
+
+Supervise heartbeat, follow keepalive, and unchanged `kind=next` reminders
+never enqueue. Those stay Monitor-local / listen-timeout.
 
 ### Config (env or local file — never checked in)
 
@@ -421,12 +455,12 @@ Body (nudge only — no mail text, secrets, or task tables):
 
 `kind` is `mail` (controller-channel / addressee types), `complete`
 (`result` / `blocked` terminal harvest), or `wake` (other waking types).
-`dispatch_id` is omitted for the journal `attention` stream. One POST per
-newly projected waking recipient row; an idempotent replay does not POST
-again.
+`dispatch_id` is omitted for the journal `attention` stream. Identity is
+`origin_node` + `event_uuid` (the journal delivery key). A crash between a
+successful POST and the delivered mark may double-wake; that is OK.
 
 Timeout defaults to 2s (`GOALFLIGHT_WAKE_WEBHOOK_TIMEOUT_S`, clamped 0.1–15).
-POST failure is logged to stderr and ignored; the journal write already
-committed.
+POST failure is logged to stderr and recorded on the outbox row; the journal
+delivery write already committed.
 
 Portable listen semantics stay in `protocols/controller-mail.md`.

--- a/protocols/controller-mail.md
+++ b/protocols/controller-mail.md
@@ -413,11 +413,14 @@ stdout monitor. Do not launch `follow` there: a stream whose lines are not watch
 provides no wakes.
 
 Hosts whose `listen` tasks die when a local-exec session drops (Grok Bot via a
-registered Mac) may also arm an optional outbound HTTP nudge so an external
-routine can wake the controller without depending on that process. The journal
-is still durable truth; the POST is promptness only and is not a second inbox.
-See `docs/hosts/grok-bot.md`. This complements exit-as-wake `listen`. It does
-not replace `listen` when local-exec is up.
+registered Mac) keep two independent doorbells: portable exit-as-wake `listen`
+and an optional outbound HTTP webhook. Either may fire; both may fire.
+Duplicate wakes are OK (peek the journal; stay quiet if nothing is pending).
+The webhook is an alternative doorbell, not a second inbox — mail bodies never
+leave the laptop journal. The operator is not the mailman. Deafness is both
+`listen` unarmed *and* the webhook failing or unconfigured. See
+`docs/hosts/grok-bot.md`. Claude keeps `supervise` on Monitor; do not treat the
+webhook as a Monitor replacement.
 
 Arm a pool of four tracked background tasks for the active lease. Four is the default
 slot count — depth is resilience, not efficiency, and survives three missed re-arms.

--- a/scripts/goalflight_doctor.py
+++ b/scripts/goalflight_doctor.py
@@ -942,6 +942,100 @@ def check_wake_coverage(project_root: Path) -> dict:
     }
 
 
+def grok_bot_host_in_use() -> bool:
+    """True when this machine looks like a Grok Bot controller host."""
+    if os.environ.get("GOALFLIGHT_CONTROLLER_HOST", "").strip().lower() == "grok-bot":
+        return True
+    skill = _grok_bot_workflows_root() / "goal-flight/SKILL.md"
+    try:
+        return skill.is_file()
+    except OSError:
+        return False
+
+
+def check_wake_webhook(project_root: Path | None = None) -> dict:
+    """Warn when a Grok Bot host has no independent webhook doorbell URL.
+
+    Unset URL is correct for Claude ``supervise`` / Monitor hosts. Grok Bot
+    keeps portable ``listen`` *and* this webhook; missing URL means only
+    one doorbell is armed. A configured URL with undelivered outbox rows
+    is also a warning: the last POST failed and is waiting for the next
+    harvest retry.
+    """
+    try:
+        import goalflight_wake_webhook
+    except Exception as exc:  # noqa: BLE001 — doctor must not abort
+        return {
+            "ok": False,
+            "configured": False,
+            "grok_bot_host": grok_bot_host_in_use(),
+            "error": f"{type(exc).__name__}: {exc}",
+        }
+    try:
+        config = goalflight_wake_webhook.load_config()
+    except Exception as exc:  # noqa: BLE001
+        return {
+            "ok": False,
+            "configured": False,
+            "grok_bot_host": grok_bot_host_in_use(),
+            "error": f"{type(exc).__name__}: {exc}",
+        }
+    configured = config is not None
+    grok_bot = grok_bot_host_in_use()
+    pending = 0
+    if configured and project_root is not None:
+        try:
+            authority = goalflight_journal.Journal.open_reader(project_root)
+            rows = authority.read_all(
+                """
+                SELECT COUNT(*) AS n FROM wake_webhook_outbox
+                WHERE delivered_at IS NULL AND abandoned_at IS NULL
+                """
+            )
+            pending = int(rows[0]["n"]) if rows else 0
+        except Exception:
+            pending = 0
+    if configured:
+        if pending:
+            return {
+                "ok": False,
+                "configured": True,
+                "pending": pending,
+                "grok_bot_host": grok_bot,
+                "hint": (
+                    f"{pending} undelivered wake-webhook row(s); last POST "
+                    "failed and retries on the next listen-visible harvest. "
+                    "Deafness is listen unarmed and webhook failing."
+                ),
+            }
+        return {
+            "ok": True,
+            "configured": True,
+            "pending": 0,
+            "grok_bot_host": grok_bot,
+            "hint": None,
+        }
+    if grok_bot:
+        return {
+            "ok": False,
+            "configured": False,
+            "grok_bot_host": True,
+            "hint": (
+                "Grok Bot host has no GOALFLIGHT_WAKE_WEBHOOK_URL "
+                "(or ~/.goal-flight/wake-webhook.json). Portable listen is "
+                "one doorbell; the webhook is the independent alternative. "
+                "Deafness is both listen unarmed and webhook failing. "
+                "See docs/hosts/grok-bot.md."
+            ),
+        }
+    return {
+        "ok": True,
+        "configured": False,
+        "grok_bot_host": False,
+        "hint": None,
+    }
+
+
 def check_resume_notes_pattern(project_root: Path) -> dict:
     """Probe `docs-private/RESUME-NOTES-*.md` for the canonical filename
     pattern: RESUME-NOTES-<YYYY-MM-DD>[-rev<N>].md. Surfaces topic-prefixed
@@ -3437,6 +3531,7 @@ def doctor(
         "controller_lease_liveness": check_controller_lease_liveness(repo),
         "seat_state_freshness": check_seat_state_freshness(),
         "wake_coverage": check_wake_coverage(repo),
+        "wake_webhook": check_wake_webhook(repo),
         "resume_notes_pattern": check_resume_notes_pattern(repo),
         "cursor": {
             "desktop_present": cursor_desktop,
@@ -3848,6 +3943,23 @@ def collect_human_lines(payload: dict) -> list[str]:
                     detail,
                 )
             )
+    wake_webhook = payload.get("wake_webhook")
+    if isinstance(wake_webhook, dict):
+        if wake_webhook.get("error"):
+            detail = str(wake_webhook["error"])
+        elif wake_webhook.get("configured"):
+            detail = "URL configured; alternative doorbell only, journal stays inbox"
+        elif wake_webhook.get("hint"):
+            detail = str(wake_webhook["hint"])
+        else:
+            detail = "unset (zero HTTP; enqueue only when a URL is configured)"
+        lines.append(
+            status_line(
+                wake_webhook.get("ok"),
+                "wake webhook doorbell",
+                detail,
+            )
+        )
     for row in (payload.get("grok") or {}).get("permission_modes") or []:
         config = row.get("config") or "config.toml"
         if row.get("status") == "present":

--- a/scripts/goalflight_journal.py
+++ b/scripts/goalflight_journal.py
@@ -103,6 +103,12 @@ CURRENT_SCHEMA_COLUMNS = {
         "stream_seq", "carrier_path", "event_type", "wake_class", "created_at",
         "projected_at", "withdrawn_at",
     ),
+    "wake_webhook_outbox": (
+        "project_root", "recipient_label", "origin_node", "event_uuid",
+        "stream_id", "stream_seq", "event_type", "created_at", "enqueued_at",
+        "delivered_at", "abandoned_at", "abandon_reason",
+        "delivery_attempts", "last_error", "retry_at",
+    ),
     "attention_items": (
         "item_id", "project_root", "item_type", "state", "source_label",
         "source_generation", "trigger_side", "reason", "payload_json", "wake_class",
@@ -125,6 +131,9 @@ MAX_PARAMETER_VALUE_BYTES = 65_536
 MAX_TRANSACTION_PARAMETER_BYTES = 1_048_576
 OUTBOX_MAX_PROJECTION_ATTEMPTS = 3
 OUTBOX_RETRY_BASE_S = 1.0
+WAKE_WEBHOOK_OUTBOX_RETRY_BASE_S = 1.0
+WAKE_WEBHOOK_OUTBOX_RETRY_CAP_S = 60.0
+WAKE_WEBHOOK_OUTBOX_FLUSH_LIMIT = 8
 # The live incident cleared within roughly one minute while the journal stayed
 # healthy. Seventy-five seconds covers that measured minute plus 15 seconds of
 # scheduler/load margin. A smaller bound repeats the observed false teardown;
@@ -981,20 +990,42 @@ def _open_readonly_connection(
         ) from fallback_exc
 
 
-def _nudge_wake_webhook_after_projection(row: object) -> None:
-    """Best-effort HTTP nudge after a waking delivery is listen-visible.
+def _wake_webhook_enqueue_configured() -> bool:
+    """True when a webhook URL is configured. Never raises. No HTTP."""
+    try:
+        import goalflight_wake_webhook
+    except ImportError:
+        return False
+    try:
+        return goalflight_wake_webhook.load_config() is not None
+    except Exception:
+        return False
+
+
+def _wake_webhook_should_enqueue_row(row: Mapping[str, object]) -> bool:
+    """Listen-visible waking delivery that is not a Monitor-local ping."""
+    try:
+        import goalflight_wake_webhook
+    except ImportError:
+        return False
+    try:
+        return goalflight_wake_webhook.should_enqueue_delivery(row)
+    except Exception:
+        return False
+
+
+def _flush_wake_webhook_after_projection(authority: "Journal") -> None:
+    """Deliver due wake-outbox rows after projection commits.
 
     Invoked only after ``_domain_write`` commits. Import and POST failures
     stay here so projection callers never see them.
     """
-    if not isinstance(row, dict):
-        return
     try:
         import goalflight_wake_webhook
     except ImportError:
         return
     try:
-        goalflight_wake_webhook.nudge_projected_delivery(row)
+        goalflight_wake_webhook.flush_due(authority)
     except Exception:
         return
 
@@ -1543,7 +1574,18 @@ class Journal:
             # shape validation: schema deltas are expected across epochs and
             # must not be misreported to an old client as journal corruption.
             self._assert_epoch_fence(connection, for_write=False)
+            created_wake_outbox = False
+            if not self._read_only_client:
+                created_wake_outbox = self._install_wake_webhook_outbox(connection)
             missing_before, malformed_before = self._current_schema_issues(connection)
+            if self._read_only_client:
+                # Readers must not require a writer-only additive table that
+                # this process cannot install. The first writer open creates it.
+                missing_before = [
+                    name
+                    for name in missing_before
+                    if name != "wake_webhook_outbox"
+                ]
             outbox_columns = tuple(
                 str(column[1])
                 for column in connection.execute("PRAGMA table_info(terminal_outbox)")
@@ -1580,7 +1622,10 @@ class Journal:
                     + ", ".join(malformed)
                 )
             repaired = (
-                retry_columns_migrated or seat_columns_migrated or bool(missing)
+                retry_columns_migrated
+                or seat_columns_migrated
+                or bool(missing)
+                or created_wake_outbox
             )
             if repaired:
                 # In-progress P3 builds could stamp epoch 3 before every final
@@ -1754,6 +1799,56 @@ class Journal:
             )
             migrated = True
         return migrated
+
+    @staticmethod
+    def _install_wake_webhook_outbox(connection: sqlite3.Connection) -> bool:
+        """Additive doorbell outbox. Safe on ordinary epoch-6 opens.
+
+        Existing journals must gain this empty table without
+        ``GOALFLIGHT_ALLOW_JOURNAL_MIGRATION``. A missing wake row is a
+        lost doorbell; requiring an explicit migrate would drop wakes
+        until an operator noticed.
+        """
+        tables = {
+            str(row[0])
+            for row in connection.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            )
+        }
+        if "wake_webhook_outbox" in tables:
+            return False
+        connection.execute(
+            """CREATE TABLE IF NOT EXISTS wake_webhook_outbox (
+                project_root TEXT NOT NULL,
+                recipient_label TEXT NOT NULL,
+                origin_node TEXT NOT NULL,
+                event_uuid TEXT NOT NULL,
+                stream_id TEXT NOT NULL,
+                stream_seq INTEGER NOT NULL
+                    CHECK (typeof(stream_seq) = 'integer' AND stream_seq >= 1),
+                event_type TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                enqueued_at TEXT NOT NULL,
+                delivered_at TEXT,
+                abandoned_at TEXT,
+                abandon_reason TEXT,
+                delivery_attempts INTEGER NOT NULL DEFAULT 0
+                    CHECK (typeof(delivery_attempts) = 'integer' AND delivery_attempts >= 0),
+                last_error TEXT,
+                retry_at TEXT,
+                PRIMARY KEY (project_root, recipient_label, origin_node, event_uuid),
+                CHECK (
+                    (delivered_at IS NULL OR abandoned_at IS NULL)
+                )
+            )"""
+        )
+        connection.execute(
+            """CREATE INDEX IF NOT EXISTS wake_webhook_outbox_due_idx
+               ON wake_webhook_outbox (
+                   delivered_at, abandoned_at, retry_at, enqueued_at
+               )"""
+        )
+        return True
 
     @staticmethod
     def _install_outbox_retry_columns(connection: sqlite3.Connection) -> bool:
@@ -1995,6 +2090,33 @@ class Journal:
                 ON delivery_events (
                     project_root, recipient_label, wake_class,
                     created_at, event_uuid, stream_id, stream_seq
+                )""",
+            """CREATE TABLE IF NOT EXISTS wake_webhook_outbox (
+                project_root TEXT NOT NULL,
+                recipient_label TEXT NOT NULL,
+                origin_node TEXT NOT NULL,
+                event_uuid TEXT NOT NULL,
+                stream_id TEXT NOT NULL,
+                stream_seq INTEGER NOT NULL
+                    CHECK (typeof(stream_seq) = 'integer' AND stream_seq >= 1),
+                event_type TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                enqueued_at TEXT NOT NULL,
+                delivered_at TEXT,
+                abandoned_at TEXT,
+                abandon_reason TEXT,
+                delivery_attempts INTEGER NOT NULL DEFAULT 0
+                    CHECK (typeof(delivery_attempts) = 'integer' AND delivery_attempts >= 0),
+                last_error TEXT,
+                retry_at TEXT,
+                PRIMARY KEY (project_root, recipient_label, origin_node, event_uuid),
+                CHECK (
+                    (delivered_at IS NULL OR abandoned_at IS NULL)
+                )
+            )""",
+            """CREATE INDEX IF NOT EXISTS wake_webhook_outbox_due_idx
+                ON wake_webhook_outbox (
+                    delivered_at, abandoned_at, retry_at, enqueued_at
                 )""",
             """CREATE TABLE IF NOT EXISTS attention_items (
                 item_id TEXT PRIMARY KEY,
@@ -3535,6 +3657,10 @@ class Journal:
         origin = self._identity_token(origin_node, label="origin node")
         event_id = self._canonical_uuid(event_uuid, label="event_uuid")
         project_root = str(self.project_root)
+        # Enqueue decision is env/file only and must happen before BEGIN.
+        # HTTP stays after commit so a failed POST cannot roll back the
+        # listen-visible harvest (the same projection ``listen`` waits on).
+        enqueue_configured = _wake_webhook_enqueue_configured()
 
         def action(connection: sqlite3.Connection) -> dict[str, object]:
             effective_recipient = recipient
@@ -3605,14 +3731,267 @@ class Journal:
             # commit and accidentally describe a later delivery or drain.
             result["recipient_cursors"] = [dict(cursor) for cursor in cursor_rows]
             result["newly_projected"] = newly_projected
+            if (
+                newly_projected
+                and enqueue_configured
+                and _wake_webhook_should_enqueue_row(result)
+            ):
+                self._enqueue_wake_webhook_outbox(connection, result)
             return result
 
-        # POST after commit: a webhook failure must not roll back the journal.
-        # This is the listen-visible harvest hook (same projection listen waits
-        # on), not a second inbox.
         committed = self._domain_write(action)
-        _nudge_wake_webhook_after_projection(committed.value)
+        if committed.committed:
+            _flush_wake_webhook_after_projection(self)
         return committed
+
+    @staticmethod
+    def _enqueue_wake_webhook_outbox(
+        connection: sqlite3.Connection,
+        row: Mapping[str, object],
+    ) -> None:
+        """Record a would-wake row in the same TX as listen-visible projection."""
+        now = utc_now()
+        connection.execute(
+            """
+            INSERT OR IGNORE INTO wake_webhook_outbox (
+                project_root, recipient_label, origin_node, event_uuid,
+                stream_id, stream_seq, event_type, created_at, enqueued_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                str(row["project_root"]),
+                str(row["recipient_label"]),
+                str(row["origin_node"]),
+                str(row["event_uuid"]),
+                str(row.get("stream_id") or ""),
+                int(row.get("stream_seq") or 1),
+                str(row.get("event_type") or ""),
+                str(row.get("created_at") or now),
+                now,
+            ),
+        )
+
+    def due_wake_webhook_outbox(self, *, limit: int = 8) -> list[dict[str, object]]:
+        """Pending doorbell rows whose backoff has elapsed."""
+        if not 1 <= limit <= 1000:
+            raise ValueError("wake webhook outbox limit must be between 1 and 1000")
+        rows = self.read_all(
+            """
+            SELECT *
+            FROM wake_webhook_outbox
+            WHERE delivered_at IS NULL AND abandoned_at IS NULL
+              AND (retry_at IS NULL OR retry_at <= ?)
+            ORDER BY COALESCE(retry_at, enqueued_at), enqueued_at, event_uuid
+            LIMIT ?
+            """,
+            (utc_now(), limit),
+        )
+        return [dict(row) for row in rows]
+
+    def wake_webhook_is_listen_visible(self, row: Mapping[str, object]) -> bool:
+        """True while the event is still a listen-visible waking delivery."""
+        origin = self._identity_token(str(row.get("origin_node") or ""), label="origin node")
+        event_id = self._canonical_uuid(str(row.get("event_uuid") or ""), label="event_uuid")
+        recipient = str(row.get("recipient_label") or "")
+        recipient = (
+            "*"
+            if recipient == "*"
+            else self._identity_token(recipient, label="recipient label")
+        )
+        project_root = str(self.project_root)
+
+        def visible_for(label: str) -> bool:
+            found = self.read_all(
+                """
+                SELECT 1
+                FROM delivery_events AS e
+                LEFT JOIN controller_stream_cursors AS c
+                  ON c.project_root = e.project_root
+                 AND c.label = ?
+                 AND c.stream_id = e.stream_id
+                WHERE e.project_root = ?
+                  AND e.origin_node = ? AND e.event_uuid = ?
+                  AND e.recipient_label IN (?, '*')
+                  AND e.projected_at IS NOT NULL
+                  AND e.withdrawn_at IS NULL
+                  AND e.wake_class = 'waking'
+                  AND e.stream_seq > COALESCE(c.position, 0)
+                LIMIT 1
+                """,
+                (label, project_root, origin, event_id, recipient if recipient != "*" else label),
+            )
+            return bool(found)
+
+        if recipient != "*":
+            return visible_for(recipient)
+        labels = [
+            str(lease.get("label") or "")
+            for lease in self.lease_records()
+            if str(lease.get("label") or "")
+        ]
+        if labels:
+            return any(visible_for(label) for label in labels if label)
+        # Orphan wildcard stays listen-visible until withdrawn. An empty
+        # roster is not "already drained" — a later claim still sees the row.
+        orphan = self.read_all(
+            """
+            SELECT 1 FROM delivery_events
+            WHERE project_root = ? AND origin_node = ? AND event_uuid = ?
+              AND recipient_label = '*'
+              AND projected_at IS NOT NULL AND withdrawn_at IS NULL
+              AND wake_class = 'waking'
+            LIMIT 1
+            """,
+            (project_root, origin, event_id),
+        )
+        return bool(orphan)
+
+    def mark_wake_webhook_delivered(
+        self,
+        *,
+        recipient_label: str,
+        origin_node: str,
+        event_uuid: str,
+    ) -> WriteResult[dict[str, object] | None]:
+        recipient = (
+            "*"
+            if recipient_label == "*"
+            else self._identity_token(recipient_label, label="recipient label")
+        )
+        origin = self._identity_token(origin_node, label="origin node")
+        event_id = self._canonical_uuid(event_uuid, label="event_uuid")
+        project_root = str(self.project_root)
+        now = utc_now()
+
+        def action(connection: sqlite3.Connection) -> dict[str, object] | None:
+            updated = connection.execute(
+                """
+                UPDATE wake_webhook_outbox
+                SET delivered_at = ?, last_error = NULL, retry_at = NULL
+                WHERE project_root = ? AND recipient_label = ?
+                  AND origin_node = ? AND event_uuid = ?
+                  AND delivered_at IS NULL AND abandoned_at IS NULL
+                """,
+                (now, project_root, recipient, origin, event_id),
+            )
+            if updated.rowcount != 1:
+                return None
+            return {
+                "recipient_label": recipient,
+                "origin_node": origin,
+                "event_uuid": event_id,
+                "delivered_at": now,
+            }
+
+        return self._domain_write(action)
+
+    def mark_wake_webhook_retry(
+        self,
+        *,
+        recipient_label: str,
+        origin_node: str,
+        event_uuid: str,
+        error: str,
+    ) -> WriteResult[dict[str, object] | None]:
+        recipient = (
+            "*"
+            if recipient_label == "*"
+            else self._identity_token(recipient_label, label="recipient label")
+        )
+        origin = self._identity_token(origin_node, label="origin node")
+        event_id = self._canonical_uuid(event_uuid, label="event_uuid")
+        project_root = str(self.project_root)
+        error_text = str(error or "POST failed")[:2000]
+
+        def action(connection: sqlite3.Connection) -> dict[str, object] | None:
+            row = connection.execute(
+                """
+                SELECT delivery_attempts FROM wake_webhook_outbox
+                WHERE project_root = ? AND recipient_label = ?
+                  AND origin_node = ? AND event_uuid = ?
+                  AND delivered_at IS NULL AND abandoned_at IS NULL
+                """,
+                (project_root, recipient, origin, event_id),
+            ).fetchone()
+            if row is None:
+                return None
+            attempts = int(row["delivery_attempts"]) + 1
+            delay = min(
+                WAKE_WEBHOOK_OUTBOX_RETRY_CAP_S,
+                WAKE_WEBHOOK_OUTBOX_RETRY_BASE_S * (2 ** max(0, attempts - 1)),
+            )
+            retry_at = _utc_after(delay)
+            updated = connection.execute(
+                """
+                UPDATE wake_webhook_outbox
+                SET delivery_attempts = ?, last_error = ?, retry_at = ?
+                WHERE project_root = ? AND recipient_label = ?
+                  AND origin_node = ? AND event_uuid = ?
+                  AND delivered_at IS NULL AND abandoned_at IS NULL
+                """,
+                (
+                    attempts,
+                    error_text,
+                    retry_at,
+                    project_root,
+                    recipient,
+                    origin,
+                    event_id,
+                ),
+            )
+            if updated.rowcount != 1:
+                raise CASMismatch("wake webhook retry lost to another sender")
+            return {
+                "recipient_label": recipient,
+                "origin_node": origin,
+                "event_uuid": event_id,
+                "delivery_attempts": attempts,
+                "retry_at": retry_at,
+            }
+
+        return self._domain_write(action)
+
+    def mark_wake_webhook_abandoned(
+        self,
+        *,
+        recipient_label: str,
+        origin_node: str,
+        event_uuid: str,
+        reason: str,
+    ) -> WriteResult[dict[str, object] | None]:
+        recipient = (
+            "*"
+            if recipient_label == "*"
+            else self._identity_token(recipient_label, label="recipient label")
+        )
+        origin = self._identity_token(origin_node, label="origin node")
+        event_id = self._canonical_uuid(event_uuid, label="event_uuid")
+        project_root = str(self.project_root)
+        now = utc_now()
+        abandon_reason = str(reason or "no-longer-visible")[:200]
+
+        def action(connection: sqlite3.Connection) -> dict[str, object] | None:
+            updated = connection.execute(
+                """
+                UPDATE wake_webhook_outbox
+                SET abandoned_at = ?, abandon_reason = ?, retry_at = NULL
+                WHERE project_root = ? AND recipient_label = ?
+                  AND origin_node = ? AND event_uuid = ?
+                  AND delivered_at IS NULL AND abandoned_at IS NULL
+                """,
+                (now, abandon_reason, project_root, recipient, origin, event_id),
+            )
+            if updated.rowcount != 1:
+                return None
+            return {
+                "recipient_label": recipient,
+                "origin_node": origin,
+                "event_uuid": event_id,
+                "abandoned_at": now,
+                "abandon_reason": abandon_reason,
+            }
+
+        return self._domain_write(action)
 
     def withdraw_delivery_event(
         self,

--- a/scripts/goalflight_journal.py
+++ b/scripts/goalflight_journal.py
@@ -1578,14 +1578,7 @@ class Journal:
             if not self._read_only_client:
                 created_wake_outbox = self._install_wake_webhook_outbox(connection)
             missing_before, malformed_before = self._current_schema_issues(connection)
-            if self._read_only_client:
-                # Readers must not require a writer-only additive table that
-                # this process cannot install. The first writer open creates it.
-                missing_before = [
-                    name
-                    for name in missing_before
-                    if name != "wake_webhook_outbox"
-                ]
+            missing_before = self._ignore_writer_only_schema_gaps(missing_before)
             outbox_columns = tuple(
                 str(column[1])
                 for column in connection.execute("PRAGMA table_info(terminal_outbox)")
@@ -1616,6 +1609,7 @@ class Journal:
             retry_columns_migrated = self._install_outbox_retry_columns(connection)
             seat_columns_migrated = self._install_attempt_seat_columns(connection)
             missing, malformed = self._current_schema_issues(connection)
+            missing = self._ignore_writer_only_schema_gaps(missing)
             if malformed:
                 self._raise_integrity_failure(
                     "epoch-6 journal has structurally invalid tables: "
@@ -1634,6 +1628,7 @@ class Journal:
                 self._install_p3_schema(connection)
                 self._install_p4_schema(connection)
                 missing, malformed = self._current_schema_issues(connection)
+                missing = self._ignore_writer_only_schema_gaps(missing)
             if missing or malformed:
                 details = []
                 if missing:
@@ -1878,8 +1873,19 @@ class Journal:
         )
         return True
 
-    @staticmethod
+    def _ignore_writer_only_schema_gaps(self, missing: list[str]) -> list[str]:
+        """Drop additive tables a reader cannot install.
+
+        ``wake_webhook_outbox`` is created on the first writer open. A
+        reader of an older epoch-6 journal must not treat that gap as
+        corruption or trigger the idempotent installer.
+        """
+        if not self._read_only_client:
+            return missing
+        return [name for name in missing if name != "wake_webhook_outbox"]
+
     def _current_schema_issues(
+        self,
         connection: sqlite3.Connection,
     ) -> tuple[list[str], list[str]]:
         tables = {

--- a/scripts/goalflight_wake_webhook.py
+++ b/scripts/goalflight_wake_webhook.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Best-effort outbound wake nudge for controller mail harvest.
+"""Durable outbound wake nudge for listen-visible harvest.
 
 This is not a second inbox and not a mail transport. The journal remains
 durable truth. When a waking delivery event becomes visible (the same
@@ -7,7 +7,16 @@ projection ``listen`` already waits on), an operator may optionally HTTP
 POST a small JSON nudge to an external host so a Grok Bot webhook routine
 can wake without depending on a flaky Mac local-exec ``listen`` session.
 
-Failure to POST never raises to the caller. Config is env/file only.
+Either doorbell may fire. Duplicate wakes are OK (the controller peeks
+the journal and stays quiet if nothing is pending). Missing a wake is
+not OK: a configured URL enqueues a journal outbox row in the same
+transaction as projection, then a sender retries until HTTP 2xx or the
+event is no longer listen-visible.
+
+Failure to POST never raises to the caller and never rolls back journal
+commit. Unset URL means zero HTTP and no enqueue (safer: a later-configured
+host does not inherit an unbounded historical outbox). Config is env/file
+only.
 """
 
 from __future__ import annotations
@@ -20,6 +29,8 @@ import sys
 import urllib.error
 import urllib.parse
 import urllib.request
+from collections.abc import Mapping
+from typing import Any
 
 
 WAKE_WEBHOOK_URL_ENV = "GOALFLIGHT_WAKE_WEBHOOK_URL"
@@ -35,6 +46,7 @@ AUTH_BEARER = "bearer"
 AUTH_X_WEBHOOK_KEY = "x-webhook-key"
 AUTH_MODES = frozenset({AUTH_BEARER, AUTH_X_WEBHOOK_KEY})
 USER_AGENT = "goal-flight-wake-webhook/1"
+DEFAULT_FLUSH_LIMIT = 8
 
 # Terminal harvest of a worker. ``blocked`` is a finished attempt, not mail.
 _COMPLETE_EVENT_TYPES = frozenset({"result", "blocked"})
@@ -52,6 +64,10 @@ _MAIL_EVENT_TYPES = frozenset(
         "finding",
         "advisory",
     }
+)
+# Supervise / follow Monitor-local pings. They are not journal doorbells.
+_MONITOR_LOCAL_EVENT_TYPES = frozenset(
+    {"heartbeat", "coverage", "next", "frontier", "keepalive"}
 )
 _ATTENTION_STREAM = "attention"
 
@@ -72,6 +88,18 @@ def classify_nudge_kind(event_type: object) -> str:
     if kind in _MAIL_EVENT_TYPES:
         return "mail"
     return "wake"
+
+
+def should_enqueue_delivery(row: Mapping[str, object] | None) -> bool:
+    """True for a listen-visible waking delivery that is not Monitor-local."""
+    if not isinstance(row, Mapping):
+        return False
+    if str(row.get("wake_class") or "") != "waking":
+        return False
+    event_type = str(row.get("event_type") or "").strip()
+    if event_type in _MONITOR_LOCAL_EVENT_TYPES:
+        return False
+    return bool(event_type)
 
 
 def default_config_path() -> Path:
@@ -155,7 +183,7 @@ def load_config() -> WakeWebhookConfig | None:
     )
 
 
-def nudge_payload(row: dict[str, object]) -> dict[str, object]:
+def nudge_payload(row: dict[str, object] | Mapping[str, object]) -> dict[str, object]:
     """Build the nudge body. No mail text, secrets, or task tables."""
     event_type = str(row.get("event_type") or "").strip()
     payload: dict[str, object] = {
@@ -207,7 +235,8 @@ def post_nudge(config: WakeWebhookConfig, payload: dict[str, object]) -> bool:
     try:
         with urllib.request.urlopen(request, timeout=config.timeout_s) as response:
             response.read()
-        return True
+            status = int(getattr(response, "status", 0) or 0)
+        return 200 <= status < 300 or status == 0
     except (urllib.error.URLError, OSError, TimeoutError, ValueError) as exc:
         print(f"wake-webhook: POST failed: {_safe_reason(exc)}", file=sys.stderr)
         return False
@@ -216,17 +245,88 @@ def post_nudge(config: WakeWebhookConfig, payload: dict[str, object]) -> bool:
         return False
 
 
-def nudge_projected_delivery(row: dict[str, object] | None) -> bool:
-    """Best-effort nudge after a waking delivery becomes listen-visible.
+def _outbox_identity(row: Mapping[str, object]) -> tuple[str, str, str]:
+    return (
+        str(row.get("recipient_label") or ""),
+        str(row.get("origin_node") or ""),
+        str(row.get("event_uuid") or ""),
+    )
 
-    Returns True only when a POST was attempted and the server accepted it.
-    Missing config, quiet events, and transport failures return False.
+
+def flush_due(authority: Any, *, limit: int = DEFAULT_FLUSH_LIMIT) -> dict[str, int]:
+    """Deliver due wake-outbox rows at-least-once. Never raises.
+
+    Marks delivered on HTTP 2xx. Failed POSTs stay pending with bounded
+    backoff. Rows the controller has already drained or withdrawn are
+    abandoned so a stale doorbell cannot retry forever.
+    """
+    summary = {"attempted": 0, "delivered": 0, "retried": 0, "abandoned": 0}
+    config = load_config()
+    if config is None:
+        return summary
+    try:
+        rows = authority.due_wake_webhook_outbox(limit=limit)
+    except Exception as exc:  # noqa: BLE001 — doorbell must not break harvest
+        print(f"wake-webhook: outbox read failed: {_safe_reason(exc)}", file=sys.stderr)
+        return summary
+    for row in rows:
+        recipient, origin, event_id = _outbox_identity(row)
+        if not recipient or not origin or not event_id:
+            continue
+        try:
+            still_visible = authority.wake_webhook_is_listen_visible(row)
+        except Exception:
+            still_visible = True
+        if not still_visible:
+            try:
+                authority.mark_wake_webhook_abandoned(
+                    recipient_label=recipient,
+                    origin_node=origin,
+                    event_uuid=event_id,
+                    reason="no-longer-listen-visible",
+                )
+                summary["abandoned"] += 1
+            except Exception as exc:  # noqa: BLE001
+                print(
+                    f"wake-webhook: abandon failed: {_safe_reason(exc)}",
+                    file=sys.stderr,
+                )
+            continue
+        summary["attempted"] += 1
+        accepted = post_nudge(config, nudge_payload(row))
+        try:
+            if accepted:
+                authority.mark_wake_webhook_delivered(
+                    recipient_label=recipient,
+                    origin_node=origin,
+                    event_uuid=event_id,
+                )
+                summary["delivered"] += 1
+            else:
+                authority.mark_wake_webhook_retry(
+                    recipient_label=recipient,
+                    origin_node=origin,
+                    event_uuid=event_id,
+                    error="POST failed",
+                )
+                summary["retried"] += 1
+        except Exception as exc:  # noqa: BLE001 — crash between POST and mark may double-wake
+            print(f"wake-webhook: outbox mark failed: {_safe_reason(exc)}", file=sys.stderr)
+    return summary
+
+
+def nudge_projected_delivery(row: dict[str, object] | None) -> bool:
+    """Compatibility gate used by unit tests of classification.
+
+    Harvest uses journal enqueue + ``flush_due``. This helper still
+    refuses quiet / Monitor-local / already-projected rows and does not
+    POST when config is missing.
     """
     if not isinstance(row, dict):
         return False
-    if str(row.get("wake_class") or "") != "waking":
-        return False
     if not row.get("newly_projected"):
+        return False
+    if not should_enqueue_delivery(row):
         return False
     config = load_config()
     if config is None:

--- a/tests/python/test_goalflight_procedural.py
+++ b/tests/python/test_goalflight_procedural.py
@@ -348,6 +348,10 @@ def test_doctor_json_shape() -> None:
     wake_coverage = payload["wake_coverage"]
     for key in ("ok", "present", "pools"):
         assert_true(f"wake_coverage.{key} present", key in wake_coverage)
+    assert_true("wake_webhook section", "wake_webhook" in payload)
+    wake_webhook = payload["wake_webhook"]
+    for key in ("ok", "configured", "grok_bot_host"):
+        assert_true(f"wake_webhook.{key} present", key in wake_webhook)
     assert_true("resume_notes_pattern section", "resume_notes_pattern" in payload)
     rnp = payload["resume_notes_pattern"]
     for key in ("present", "count", "pattern_violations", "ok"):

--- a/tests/python/test_wake_webhook.py
+++ b/tests/python/test_wake_webhook.py
@@ -1,8 +1,9 @@
-"""Optional outbound wake-webhook nudge on listen-visible mail harvest.
+"""Durable outbound wake-webhook doorbell on listen-visible mail harvest.
 
 The journal is durable truth. When GOALFLIGHT_WAKE_WEBHOOK_URL is unset,
-harvest must not open a socket. When it is set, one POST follows a newly
-projected waking delivery. A failed POST must not drop the journal write.
+harvest must not open a socket and must not enqueue. When it is set, a
+wake-outbox row is written in the same transaction as projection and a
+sender POSTs at-least-once. A failed POST must not drop the journal write.
 """
 
 from __future__ import annotations
@@ -11,9 +12,11 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import json
 import os
 from pathlib import Path
+import sqlite3
 import subprocess
 import sys
 import threading
+import uuid
 import urllib.request
 
 import pytest
@@ -23,6 +26,7 @@ ROOT = Path(__file__).resolve().parents[2]
 SCRIPTS = ROOT / "scripts"
 sys.path.insert(0, str(SCRIPTS))
 
+import goalflight_doctor as doctor  # noqa: E402
 import goalflight_journal as journal  # noqa: E402
 import goalflight_messages as messages  # noqa: E402
 import goalflight_wake_webhook as webhook  # noqa: E402
@@ -110,6 +114,28 @@ def test_classify_nudge_kind_splits_mail_wake_complete() -> None:
     assert webhook.classify_nudge_kind("blocked") == "complete"
     assert webhook.classify_nudge_kind("user_need") == "wake"
     assert webhook.classify_nudge_kind("steering") == "wake"
+
+
+def test_should_enqueue_skips_heartbeat_next_and_quiet() -> None:
+    waking_mail = {
+        "wake_class": "waking",
+        "event_type": "controller-notice",
+        "newly_projected": True,
+    }
+    assert webhook.should_enqueue_delivery(waking_mail) is True
+    assert webhook.should_enqueue_delivery({**waking_mail, "event_type": "result"}) is True
+    assert (
+        webhook.should_enqueue_delivery({**waking_mail, "wake_class": "quiet"}) is False
+    )
+    assert (
+        webhook.should_enqueue_delivery({**waking_mail, "event_type": "heartbeat"})
+        is False
+    )
+    assert webhook.should_enqueue_delivery({**waking_mail, "event_type": "next"}) is False
+    assert (
+        webhook.should_enqueue_delivery({**waking_mail, "event_type": "coverage"})
+        is False
+    )
 
 
 def test_load_config_unset_means_none(
@@ -209,6 +235,7 @@ def test_unset_url_means_zero_http_on_mail_harvest(
     )
     assert len(rows) == 1
     assert rows[0]["projected_at"] is not None
+    assert authority.due_wake_webhook_outbox() == []
 
 
 def test_mail_harvest_posts_one_nudge(
@@ -251,6 +278,13 @@ def test_mail_harvest_posts_one_nudge(
             "dispatch_id": "mail-1",
         }
         assert "nudge-mail" not in json.dumps(body)
+        outbox = authority.read_all(
+            "SELECT delivered_at, abandoned_at FROM wake_webhook_outbox WHERE stream_id = ?",
+            ("mail-1",),
+        )
+        assert len(outbox) == 1
+        assert outbox[0]["delivered_at"] is not None
+        assert outbox[0]["abandoned_at"] is None
 
 
 def test_complete_harvest_posts_complete_kind(
@@ -297,6 +331,19 @@ def test_journal_write_survives_failed_post(
     )
     assert len(rows) == 1
     assert rows[0]["projected_at"] is not None
+    pending = authority.read_all(
+        """
+        SELECT event_type, delivered_at, abandoned_at, delivery_attempts, retry_at
+        FROM wake_webhook_outbox WHERE stream_id = ?
+        """,
+        ("fail-1",),
+    )
+    assert len(pending) == 1
+    assert pending[0]["event_type"] == "controller-notice"
+    assert pending[0]["delivered_at"] is None
+    assert pending[0]["abandoned_at"] is None
+    assert int(pending[0]["delivery_attempts"]) >= 1
+    assert pending[0]["retry_at"] is not None
 
     monkeypatch.setenv("GOALFLIGHT_WAKE_WEBHOOK_URL", "http://127.0.0.1:1/closed")
     monkeypatch.setenv("GOALFLIGHT_WAKE_WEBHOOK_TIMEOUT_S", "0.2")
@@ -344,3 +391,224 @@ def test_quiet_projection_does_not_post(monkeypatch: pytest.MonkeyPatch) -> None
         )
         is False
     )
+    assert (
+        webhook.nudge_projected_delivery(
+            {
+                "newly_projected": True,
+                "wake_class": "waking",
+                "event_type": "heartbeat",
+                "recipient_label": "alice",
+                "project_root": "/tmp/p",
+                "stream_id": "s",
+            }
+        )
+        is False
+    )
+    assert (
+        webhook.nudge_projected_delivery(
+            {
+                "newly_projected": True,
+                "wake_class": "waking",
+                "event_type": "next",
+                "recipient_label": "alice",
+                "project_root": "/tmp/p",
+                "stream_id": "s",
+            }
+        )
+        is False
+    )
+
+
+def _force_outbox_due(authority: journal.Journal, stream_id: str) -> None:
+    with sqlite3.connect(authority.path) as connection:
+        connection.execute(
+            """
+            UPDATE wake_webhook_outbox
+            SET retry_at = '1970-01-01T00:00:00+00:00'
+            WHERE stream_id = ? AND delivered_at IS NULL AND abandoned_at IS NULL
+            """,
+            (stream_id,),
+        )
+        connection.commit()
+
+
+def test_retry_succeeds_after_failed_post(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    project = _git_project(tmp_path)
+    authority = journal.Journal.create(project)
+    _claim(authority, "alice")
+    with _WebhookServer(status=500) as failing:
+        monkeypatch.setenv("GOALFLIGHT_WAKE_WEBHOOK_URL", failing.url)
+        posted = _post_mail(project, tmp_path / "messages", "alice", dispatch_id="retry-1")
+        assert posted["recorded"] is True
+        assert len(failing.requests) == 1
+    _force_outbox_due(authority, "retry-1")
+    with _WebhookServer() as recovering:
+        monkeypatch.setenv("GOALFLIGHT_WAKE_WEBHOOK_URL", recovering.url)
+        summary = webhook.flush_due(authority)
+        assert summary["delivered"] == 1
+        assert summary["retried"] == 0
+        assert len(recovering.requests) == 1
+        body = json.loads(recovering.requests[0]["body"])
+        assert body["kind"] == "mail"
+        assert "nudge-mail" not in json.dumps(body)
+    delivered = authority.read_all(
+        "SELECT delivered_at FROM wake_webhook_outbox WHERE stream_id = ?",
+        ("retry-1",),
+    )
+    assert delivered[0]["delivered_at"] is not None
+
+
+def test_drained_event_abandons_outbox_without_another_post(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    project = _git_project(tmp_path)
+    authority = journal.Journal.create(project)
+    lease = _claim(authority, "alice")
+    with _WebhookServer(status=500) as failing:
+        monkeypatch.setenv("GOALFLIGHT_WAKE_WEBHOOK_URL", failing.url)
+        posted = _post_mail(project, tmp_path / "messages", "alice", dispatch_id="drain-1")
+        assert posted["recorded"] is True
+        assert len(failing.requests) == 1
+    peek = authority.cursor_peek("alice", nonce=lease.nonce)
+    advanced = authority.advance_cursor(
+        "alice",
+        nonce=lease.nonce,
+        expected_cursor_version=peek.cursor_version,
+        expected_stream_snapshots=peek.stream_snapshots,
+        advances={"drain-1": 1},
+        actor="controller:test:relay-drain",
+    )
+    assert advanced.committed
+    _force_outbox_due(authority, "drain-1")
+    with _WebhookServer() as recovering:
+        monkeypatch.setenv("GOALFLIGHT_WAKE_WEBHOOK_URL", recovering.url)
+        summary = webhook.flush_due(authority)
+        assert summary["abandoned"] == 1
+        assert summary["attempted"] == 0
+        assert recovering.requests == []
+    abandoned = authority.read_all(
+        "SELECT abandoned_at, abandon_reason FROM wake_webhook_outbox WHERE stream_id = ?",
+        ("drain-1",),
+    )
+    assert abandoned[0]["abandoned_at"] is not None
+    assert abandoned[0]["abandon_reason"] == "no-longer-listen-visible"
+
+
+def test_later_harvest_retries_due_outbox(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The harvest/projection path is the sender; listen is not blocked on HTTP."""
+    project = _git_project(tmp_path)
+    authority = journal.Journal.create(project)
+    _claim(authority, "alice")
+    with _WebhookServer(status=500) as failing:
+        monkeypatch.setenv("GOALFLIGHT_WAKE_WEBHOOK_URL", failing.url)
+        posted = _post_mail(project, tmp_path / "messages", "alice", dispatch_id="first-1")
+        assert posted["recorded"] is True
+        assert len(failing.requests) == 1
+    _force_outbox_due(authority, "first-1")
+    with _WebhookServer() as recovering:
+        monkeypatch.setenv("GOALFLIGHT_WAKE_WEBHOOK_URL", recovering.url)
+        later = _post_mail(project, tmp_path / "messages", "alice", dispatch_id="second-1")
+        assert later["recorded"] is True
+        kinds = [json.loads(req["body"])["dispatch_id"] for req in recovering.requests]
+        assert "first-1" in kinds
+        assert "second-1" in kinds
+        assert all("nudge-mail" not in req["body"].decode() for req in recovering.requests)
+
+
+def test_wildcard_orphan_still_posts(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    project = _git_project(tmp_path)
+    authority = journal.Journal.create(project)
+    event_id = str(uuid.uuid4())
+    recorded = authority.record_delivery_event(
+        recipient_label="*",
+        origin_node="test",
+        event_uuid=event_id,
+        stream_id="orphan-1",
+        stream_seq=1,
+        carrier_path=tmp_path / "carrier.jsonl",
+        event_type="user_need",
+        wake_class="waking",
+        created_at=journal.utc_now(),
+    )
+    assert recorded.committed
+    with _WebhookServer() as server:
+        monkeypatch.setenv("GOALFLIGHT_WAKE_WEBHOOK_URL", server.url)
+        marked = authority.mark_delivery_projected(
+            recipient_label="*",
+            origin_node="test",
+            event_uuid=event_id,
+        )
+        assert marked.committed
+        assert len(server.requests) == 1
+        body = json.loads(server.requests[0]["body"])
+        assert body["kind"] == "wake"
+        assert body["controller_label"] == "*"
+        assert "secret" not in json.dumps(body).lower()
+    abandoned = authority.read_all(
+        "SELECT abandoned_at, delivered_at FROM wake_webhook_outbox WHERE event_uuid = ?",
+        (event_id,),
+    )
+    assert len(abandoned) == 1
+    assert abandoned[0]["abandoned_at"] is None
+    assert abandoned[0]["delivered_at"] is not None
+
+
+def test_existing_journal_gains_outbox_without_upgrade_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv(journal.ALLOW_MIGRATION_ENV, raising=False)
+    project = _git_project(tmp_path)
+    authority = journal.Journal.create(project)
+    with sqlite3.connect(authority.path) as connection:
+        connection.execute("DROP TABLE wake_webhook_outbox")
+        connection.commit()
+    reopened = journal.Journal(project)
+    tables = {
+        str(row["name"])
+        for row in reopened.read_all(
+            "SELECT name FROM sqlite_master WHERE type = 'table'"
+        )
+    }
+    assert "wake_webhook_outbox" in tables
+    columns = tuple(
+        str(row["name"])
+        for row in reopened.read_all("PRAGMA table_info(wake_webhook_outbox)")
+    )
+    assert columns == journal.CURRENT_SCHEMA_COLUMNS["wake_webhook_outbox"]
+
+
+def test_doctor_warns_when_grok_bot_host_missing_url(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv("GOALFLIGHT_WAKE_WEBHOOK_URL", raising=False)
+    monkeypatch.setenv("GOALFLIGHT_WAKE_WEBHOOK_CONFIG", os.devnull)
+    monkeypatch.delenv("GOALFLIGHT_CONTROLLER_HOST", raising=False)
+    monkeypatch.setenv("GOALFLIGHT_GROK_BOT_WORKFLOWS", str(tmp_path / "missing-workflows"))
+    healthy = doctor.check_wake_webhook()
+    assert healthy["ok"] is True
+    assert healthy["configured"] is False
+
+    monkeypatch.setenv("GOALFLIGHT_CONTROLLER_HOST", "grok-bot")
+    warned = doctor.check_wake_webhook()
+    assert warned["ok"] is False
+    assert warned["grok_bot_host"] is True
+    assert "GOALFLIGHT_WAKE_WEBHOOK_URL" in str(warned.get("hint") or "")
+
+    workflows = tmp_path / "workflows" / "goal-flight"
+    workflows.mkdir(parents=True)
+    (workflows / "SKILL.md").write_text("# grok-bot\n", encoding="utf-8")
+    monkeypatch.delenv("GOALFLIGHT_CONTROLLER_HOST", raising=False)
+    monkeypatch.setenv("GOALFLIGHT_GROK_BOT_WORKFLOWS", str(tmp_path / "workflows"))
+    skill_warned = doctor.check_wake_webhook()
+    assert skill_warned["ok"] is False
+
+    monkeypatch.setenv("GOALFLIGHT_WAKE_WEBHOOK_URL", "http://127.0.0.1:9/wake")
+    configured = doctor.check_wake_webhook()
+    assert configured["ok"] is True
+    assert configured["configured"] is True

--- a/tests/python/test_wake_webhook.py
+++ b/tests/python/test_wake_webhook.py
@@ -583,6 +583,29 @@ def test_existing_journal_gains_outbox_without_upgrade_env(
     assert columns == journal.CURRENT_SCHEMA_COLUMNS["wake_webhook_outbox"]
 
 
+def test_reader_opens_journal_missing_outbox_without_upgrade_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv(journal.ALLOW_MIGRATION_ENV, raising=False)
+    project = _git_project(tmp_path)
+    authority = journal.Journal.create(project)
+    with sqlite3.connect(authority.path) as connection:
+        connection.execute("DROP TABLE wake_webhook_outbox")
+        connection.commit()
+    reader = journal.Journal.open_reader(project)
+    tables = {
+        str(row["name"])
+        for row in reader.read_all("SELECT name FROM sqlite_master WHERE type = 'table'")
+    }
+    assert "wake_webhook_outbox" not in tables
+    writer = journal.Journal(project)
+    restored = {
+        str(row["name"])
+        for row in writer.read_all("SELECT name FROM sqlite_master WHERE type = 'table'")
+    }
+    assert "wake_webhook_outbox" in restored
+
+
 def test_doctor_warns_when_grok_bot_host_missing_url(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Rebased onto current `main` after PR #5 (optional wake-webhook nudge) and later merges (#11–#13 and following). The durable-outbox work is two commits on top of `origin/main`; stacked history from `cursor/wake-webhook-nudge-9710` was dropped as redundant.

Head: `0f985a0c2a245f9554c832687c838301c0f33537`

## Two planes (locked)

1. **Inbox / truth** = journal on the laptop. Mail bodies, task tables, and secrets never enter the webhook. Payload stays the tiny nudge: `kind` (`mail`|`wake`|`complete`), `controller_label`, `project_root`, `event_type`, optional `dispatch_id`.
2. **Wake** = how a host without a persistent stdout Monitor gets a turn. Claude keeps `supervise` on Monitor. Grok Bot keeps portable `listen` (exit-as-wake) **and** this webhook as the independent alternative doorbell.

Either doorbell may fire; both may fire. Duplicate wakes are OK (controller peeks journal, stays quiet if nothing). Missing a wake is not OK. Deafness is both `listen` unarmed **and** the webhook failing or unconfigured.

## Call sites

The hook is the listen-visible delivery projection (`Journal.mark_delivery_projected`):

- Enqueue decision is env/file only and happens **before BEGIN**.
- A configured URL writes `wake_webhook_outbox` in the same transaction as projection.
- HTTP flush runs only after `_domain_write` commits. A failed POST never rolls back the journal.
- Later harvests retry due rows with bounded backoff (1s…60s). No parallel daemon.

Producers already reach that method:

- Controller mail harvest: `goalflight_messages.py` → `mark_delivery_projected`
- Worker terminal harvest: `Journal.project_terminal_outbox` → `mark_delivery_projected`

## Safer default

- Unset URL: zero HTTP **and** no enqueue. A later-configured host does not inherit an unbounded historical outbox.
- If a URL was configured and POST failed: the outbox row stays pending; the next harvest retries.
- Doctor warns when a Grok Bot host is in use and the URL is missing, or when a configured URL has undelivered rows.
- Readers of an older epoch-6 journal may open without the additive table; the first writer install creates it.

Supervise heartbeat, follow keepalive, and unchanged `kind=next` / coverage never enqueue.

## Tests

Hermetic suite in `tests/python/test_wake_webhook.py` (17 passed). No live Grok Bot network.

## Rebase notes

- Resolved `docs/README.md` against the grok-bot host-port row that landed on main.
- Dropped a duplicate `_grok_bot_workflows_root` that the original commit added after main already grew the same helper.
- Dual-doorbell wording is now also on the grok-bot host wrapper (`configs/grok-bot/skills/goal-flight/SKILL.md`) that landed in PR #9.
- Equivalent dual-doorbell outbox did **not** already exist on main.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-04699252-5c99-4047-96ce-9d281eda850d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04699252-5c99-4047-96ce-9d281eda850d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

