### PR TITLE
Wrap bash-shape cursor with sandbox-exec for --os-sandbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ incremented when meaningful skill behaviour changes.
 
 ### Fixed
 
+- Bash-shape `--agent cursor` (any model, including `--model kimi-k3-high`)
+  honours `--os-sandbox read-only` / `workspace-write` on macOS by wrapping
+  the worker in `sandbox-exec`. cursor-cli has no read-only primitive; the
+  runner does not pass a refused cursor sandbox flag. Moonshot (`--agent
+  moonshot`) is unchanged. Linux/other hosts still refuse the flag.
 - `supervise` backlog cap keys on envelope identity, not raw line count.
   Duplicate copies of one cursor snapshot still collapse as `cursor-lag` /
   `child-backlog`. Distinct envelopes (new cursor versions, unique headlines,

--- a/adapters/cursor.json
+++ b/adapters/cursor.json
@@ -284,7 +284,7 @@
           "off"
         ]
       },
-      "notes": "Dispatch-level worker subprocess wrapper; not a cursor-agent flag. Permits temp and Cursor host-state writes while fencing project writes by profile."
+      "notes": "cursor-cli has no read-only/workspace-write primitive. Enforcement is runner:sandbox-exec (macOS Seatbelt wrap of the worker subprocess), not a cursor-agent flag. Permits temp and Cursor host-state writes while fencing project writes by profile. Linux/WSL/Windows keep off-only."
     },
     "auto_approve_detection": {
       "probes": [

--- a/scripts/goalflight_dispatch.py
+++ b/scripts/goalflight_dispatch.py
@@ -559,6 +559,15 @@ def _supported_os_sandbox_profile(args) -> str | None:
         return _effective_os_sandbox(args)
     if agent == "moonshot" and shape != "acp":
         return OS_SANDBOX_OFF
+    if agent in CURSOR_AGENTS and shape != "acp":
+        requested = _requested_os_sandbox(args)
+        if requested is None:
+            return None
+        from goalflight_adapter_readiness import validate_os_sandbox_request
+
+        if validate_os_sandbox_request(agent, requested) is None:
+            return requested
+        return None
     return None
 
 
@@ -572,6 +581,8 @@ def _enforced_os_sandbox_profile(args, *, worker_pid: int | None) -> str | None:
         return _effective_os_sandbox(args)
     if agent == "moonshot" and shape != "acp":
         return OS_SANDBOX_OFF
+    if agent in CURSOR_AGENTS and shape != "acp":
+        return _supported_os_sandbox_profile(args)
     return None
 
 
@@ -652,16 +663,18 @@ def _validate_os_sandbox_boundary(args) -> None:
 def _os_sandbox_enforced_by_launch(args) -> bool:
     """True when an explicit --os-sandbox actually constrains this launch path.
 
-    Bash-shape grok/cursor/claude ignore the flag (no CLI/OS mapping). ACP
-    honours it only when the adapter and platform can wrap the worker.
-    An accepted-but-inert safety flag is worse than a refusal.
+    Bash-shape grok/claude ignore the flag (no CLI/OS mapping). Cursor bash
+    uses the same runner:sandbox-exec wrap as ACP (macOS Seatbelt; no
+    cursor-cli sandbox flag). ACP honours the flag only when the adapter
+    and platform can wrap the worker. An accepted-but-inert safety flag is
+    worse than a refusal.
     """
     explicit = getattr(args, "os_sandbox", None)
     if explicit not in OS_SANDBOX_PROFILES:
         return True
     agent = str(getattr(args, "agent", "") or "")
     shape = getattr(args, "shape", "bash")
-    if shape == "acp":
+    if shape == "acp" or agent in CURSOR_AGENTS:
         from goalflight_adapter_readiness import validate_os_sandbox_request
 
         return validate_os_sandbox_request(agent, explicit) is None
@@ -706,7 +719,8 @@ def _validate_agent_os_sandbox(args) -> None:
                 "with an inert safety flag. "
                 "Use --read-only instead (grok: deny rules for Write/Edit/Bash; "
                 "bash-shape codex: codex --sandbox read-only). --os-sandbox is "
-                "honoured by bash-shape codex and by ACP shapes whose adapter "
+                "honoured by bash-shape codex, bash-shape cursor (macOS "
+                "sandbox-exec wrap), and by ACP shapes whose adapter "
                 "and platform can enforce it."
             )
         return
@@ -716,7 +730,8 @@ def _validate_agent_os_sandbox(args) -> None:
             f"shape={shape}; refusing to launch with an inert safety flag. "
             "Use --read-only instead (grok: deny rules for Write/Edit/Bash; "
             "bash-shape codex: codex --sandbox read-only). --os-sandbox is "
-            "honoured by bash-shape codex and by ACP shapes whose adapter "
+            "honoured by bash-shape codex, bash-shape cursor (macOS "
+            "sandbox-exec wrap), and by ACP shapes whose adapter "
             "and platform can enforce it."
         )
 
@@ -17126,11 +17141,49 @@ def _apply_fast_mode(args) -> None:
         print("FAST: urgent — forcing --priority critical to skip the queue", file=sys.stderr)
 
 
+def _wrap_cursor_os_sandbox(argv: list[str], args) -> list[str]:
+    """Wrap cursor-agent with sandbox-exec when the adapter+platform can enforce.
+
+    cursor-cli has no read-only/workspace-write primitive. Enforcement is the
+    same runner:sandbox-exec Seatbelt wrap ACP already uses for cursor/grok/
+    codex. Do not invent a cursor-cli --sandbox flag — the CLI refuses it.
+    Linux/other hosts: validate_os_sandbox_request fails closed, so this is a
+    no-op and dispatch refuses an explicit --os-sandbox as today.
+    """
+    if not argv:
+        return argv
+    agent = str(getattr(args, "agent", "") or "")
+    if agent not in CURSOR_AGENTS:
+        return argv
+    requested = _requested_os_sandbox(args)
+    if requested in {None, OS_SANDBOX_OFF}:
+        return argv
+    from goalflight_adapter_readiness import validate_os_sandbox_request
+
+    if validate_os_sandbox_request(agent, requested) is not None:
+        return argv
+    from goalflight_os_sandbox import prepare_os_sandbox_command
+
+    cwd = os.path.abspath(getattr(args, "cwd", None) or ".")
+    prepared = prepare_os_sandbox_command(
+        argv[0],
+        list(argv[1:]),
+        cwd=cwd,
+        os_sandbox=requested,
+        agent=agent,
+    )
+    return [prepared.command, *prepared.args]
+
+
 def build_worker(args, prompt_path, raw_argv: list[str]):
     """Return (argv, stdin_path). Explicit `-- <cmd>` overrides any preset.
     Presets encode the canonical SAFE, non-interactive invocation per worker.
     `prompt_path` is the already-materialized prompt file (or None for raw)."""
     if raw_argv:
+        # Raw `--` still honours --os-sandbox for cursor: the flag is a
+        # dispatch-level claim, not a preset-only wrap.
+        if str(getattr(args, "agent", "") or "") in CURSOR_AGENTS:
+            return _wrap_cursor_os_sandbox(list(raw_argv), args), None
         return raw_argv, None  # raw escape hatch; stdin = DEVNULL
     # codex's own --sandbox value for the effective OS sandbox profile.
     # "off" -> danger-full-access (Seatbelt disabled) for trusted local GPU/perf.
@@ -17290,7 +17343,8 @@ def build_worker(args, prompt_path, raw_argv: list[str]):
         if model:
             argv += ["--model", str(model)]
         # Prompt via stdin: the file can be 5-20KB and argv would truncate.
-        return argv, prompt_path
+        # OS sandbox is a runner wrap, not a cursor-agent flag.
+        return _wrap_cursor_os_sandbox(argv, args), prompt_path
     if args.agent == "claude":
         if not prompt_path:
             raise DispatchUsageError("claude resume/launch requires a prompt file")
@@ -17395,13 +17449,15 @@ def _build_launch_parser() -> argparse.ArgumentParser:
     parser.add_argument("--os-sandbox", type=_parse_os_sandbox_arg, default=None,
                         metavar="{workspace-write,read-only,off}",
                         help="OS sandbox profile. Honoured by bash-shape codex (maps to "
-                             "codex --sandbox) and by ACP shapes whose adapter and platform "
-                             "can wrap the worker (macOS sandbox-exec). Unset = workspace-write "
-                             "for bash-shape codex. An accepted-but-inert request is refused; "
-                             "grok bash should pass --read-only instead. 'off' disables codex's "
-                             "Seatbelt sandbox (codex --sandbox danger-full-access) for TRUSTED "
-                             "LOCAL GPU/perf work. Sanctioned adapter profile, DISTINCT from the "
-                             "always-forbidden --dangerously-*/--no-sandbox bypass flags.")
+                             "codex --sandbox), bash-shape cursor (macOS sandbox-exec wrap; "
+                             "cursor-cli has no read-only flag), and by ACP shapes whose "
+                             "adapter and platform can wrap the worker (macOS sandbox-exec). "
+                             "Unset = workspace-write for bash-shape codex. An accepted-but-inert "
+                             "request is refused; grok bash should pass --read-only instead. "
+                             "'off' disables codex's Seatbelt sandbox (codex --sandbox "
+                             "danger-full-access) for TRUSTED LOCAL GPU/perf work. Sanctioned "
+                             "adapter profile, DISTINCT from the always-forbidden "
+                             "--dangerously-*/--no-sandbox bypass flags.")
     parser.add_argument("--priority", choices=["critical", "normal", "bulk"], default="normal",
                         help="Capacity lane. bulk = review storms / batch work (reserves the last "
                              "machine+pool slots for others); critical = fix dispatches (may borrow "

--- a/tests/python/test_dispatch_argv_fidelity.py
+++ b/tests/python/test_dispatch_argv_fidelity.py
@@ -742,8 +742,6 @@ def test_inert_os_sandbox_is_refused_per_combination() -> None:
         ("grok-code", "bash", "workspace-write"),
         ("grok-code", "bash", "off"),
         ("grok-research", "bash", "read-only"),
-        ("cursor", "bash", "read-only"),
-        ("cursor-agent", "bash", "workspace-write"),
         ("claude", "bash", "read-only"),
         ("claude", "acp", "read-only"),
         ("claude-acp", "acp", "workspace-write"),
@@ -753,6 +751,8 @@ def test_inert_os_sandbox_is_refused_per_combination() -> None:
             ("grok-acp", "acp", "read-only"),
             ("codex-acp", "acp", "workspace-write"),
             ("cursor", "acp", "read-only"),
+            ("cursor", "bash", "read-only"),
+            ("cursor-agent", "bash", "workspace-write"),
         )
     for agent, shape, profile in refused:
         args = argparse.Namespace(
@@ -788,6 +788,12 @@ def test_honored_os_sandbox_and_read_only_still_launch() -> None:
             agent="moonshot", shape="bash", os_sandbox="off", read_only=False
         ),
         argparse.Namespace(
+            agent="cursor", shape="bash", os_sandbox="off", read_only=False
+        ),
+        argparse.Namespace(
+            agent="cursor-agent", shape="bash", os_sandbox="off", read_only=False
+        ),
+        argparse.Namespace(
             agent="grok-acp", shape="acp", os_sandbox="off", read_only=False
         ),
         argparse.Namespace(
@@ -813,6 +819,25 @@ def test_honored_os_sandbox_and_read_only_still_launch() -> None:
             ),
             argparse.Namespace(
                 agent="cursor", shape="acp", os_sandbox="read-only", read_only=False
+            ),
+            argparse.Namespace(
+                agent="cursor", shape="bash", os_sandbox="read-only", read_only=False
+            ),
+            argparse.Namespace(
+                agent="cursor", shape="bash", os_sandbox="workspace-write", read_only=False
+            ),
+            argparse.Namespace(
+                agent="cursor-agent",
+                shape="bash",
+                os_sandbox="workspace-write",
+                read_only=False,
+            ),
+            argparse.Namespace(
+                agent="cursor",
+                shape="bash",
+                os_sandbox="read-only",
+                read_only=False,
+                model="kimi-k3-high",
             ),
         )
     for args in allowed:

--- a/tests/python/test_dispatch_os_sandbox.py
+++ b/tests/python/test_dispatch_os_sandbox.py
@@ -11,14 +11,26 @@ Repo convention: case_* functions invoked by main(), run as `python <file>.py`.
 from __future__ import annotations
 
 import argparse
+from contextlib import contextmanager
 import json
 import sys
 from pathlib import Path
+from unittest import mock
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
+import goalflight_adapter_readiness as readiness  # noqa: E402
 import goalflight_dispatch as d  # noqa: E402
+import goalflight_os_sandbox as sandbox  # noqa: E402
+
+_CURSOR_REFUSED_SANDBOX_FLAGS = (
+    "--sandbox",
+    "--os-sandbox",
+    "--no-sandbox",
+    "--disable-sandbox",
+    "--sandbox-disable",
+)
 
 
 def _args(**kw):
@@ -149,6 +161,170 @@ def case_profile_survives_submit_drain() -> None:
     assert "--os-sandbox" not in r_def and "--read-only" not in r_def, r_def
 
 
+@contextmanager
+def _force_darwin_sandbox_exec():
+    """Hermetic Darwin + sandbox-exec so argv wrap is testable on Linux CI."""
+
+    def _which(name: str) -> str | None:
+        if name == "sandbox-exec":
+            return "/usr/bin/sandbox-exec"
+        return None
+
+    with (
+        mock.patch.object(sandbox, "os_sandbox_platform_key", return_value="darwin"),
+        mock.patch.object(
+            sandbox,
+            "platform_supported_os_sandbox_profiles",
+            return_value=["off", "read-only", "workspace-write"],
+        ),
+        mock.patch.object(sandbox.goalflight_compat, "is_windows", return_value=False),
+        mock.patch.object(sandbox.shutil, "which", side_effect=_which),
+        mock.patch.object(readiness, "os_sandbox_platform_key", return_value="darwin"),
+        mock.patch.object(
+            readiness,
+            "platform_supported_os_sandbox_profiles",
+            return_value=["off", "read-only", "workspace-write"],
+        ),
+    ):
+        yield
+
+
+def _cursor_agent_tail(argv: list[str]) -> list[str]:
+    try:
+        return argv[argv.index("cursor-agent") :]
+    except ValueError as exc:
+        raise AssertionError(f"cursor-agent missing from argv: {argv}") from exc
+
+
+def case_cursor_read_only_argv_wraps_sandbox_exec_on_darwin() -> None:
+    """Controllers keep --os-sandbox read-only; runner wraps, cursor-cli does not."""
+    with _force_darwin_sandbox_exec():
+        for agent, model in (
+            ("cursor", None),
+            ("cursor", "kimi-k3-high"),
+            ("cursor-agent", "kimi-k3-high"),
+        ):
+            argv, stdin_path = d.build_worker(
+                _args(
+                    agent=agent,
+                    os_sandbox="read-only",
+                    cwd=str(REPO_ROOT),
+                    model=model,
+                ),
+                "/tmp/p.md",
+                [],
+            )
+            assert Path(argv[0]).name == "sandbox-exec", (agent, model, argv)
+            assert argv[1] == "-p", (agent, model, argv)
+            tail = _cursor_agent_tail(argv)
+            assert tail[0] == "cursor-agent", (agent, model, argv)
+            for flag in _CURSOR_REFUSED_SANDBOX_FLAGS:
+                assert flag not in tail, (agent, model, flag, tail)
+            assert not any("dangerously" in part for part in tail), (agent, model, tail)
+            if model:
+                assert tail[tail.index("--model") + 1] == model, (agent, model, tail)
+            assert stdin_path == "/tmp/p.md", stdin_path
+
+        workspace_argv, _ = d.build_worker(
+            _args(agent="cursor", os_sandbox="workspace-write", cwd=str(REPO_ROOT)),
+            "/tmp/p.md",
+            [],
+        )
+        assert Path(workspace_argv[0]).name == "sandbox-exec", workspace_argv
+        assert "--sandbox" not in _cursor_agent_tail(workspace_argv), workspace_argv
+
+        off_argv, _ = d.build_worker(
+            _args(agent="cursor", os_sandbox="off", cwd=str(REPO_ROOT)),
+            "/tmp/p.md",
+            [],
+        )
+        assert off_argv[0] == "cursor-agent", off_argv
+        assert "sandbox-exec" not in off_argv[0], off_argv
+
+        read_only_alias, _ = d.build_worker(
+            _args(agent="cursor", read_only=True, os_sandbox=None, cwd=str(REPO_ROOT)),
+            "/tmp/p.md",
+            [],
+        )
+        assert Path(read_only_alias[0]).name == "sandbox-exec", read_only_alias
+        assert "--sandbox" not in _cursor_agent_tail(read_only_alias), read_only_alias
+
+        d._validate_agent_os_sandbox(
+            _args(agent="cursor", shape="bash", os_sandbox="read-only", cwd=str(REPO_ROOT))
+        )
+
+        raw = ["cursor-agent", "-p", "--force", "--trust", "--output-format", "text"]
+        raw_wrapped, raw_stdin = d.build_worker(
+            _args(agent="cursor", os_sandbox="read-only", cwd=str(REPO_ROOT)),
+            "/tmp/p.md",
+            raw,
+        )
+        assert Path(raw_wrapped[0]).name == "sandbox-exec", raw_wrapped
+        assert raw_stdin is None, raw_stdin
+        assert "--sandbox" not in _cursor_agent_tail(raw_wrapped), raw_wrapped
+
+
+def case_cursor_read_only_argv_stays_unwrapped_off_darwin() -> None:
+    """Linux/other hosts keep documented off-only behavior; no invented CLI flag."""
+    if sandbox.os_sandbox_platform_key() == "darwin":
+        return
+    argv, _ = d.build_worker(
+        _args(agent="cursor", os_sandbox="read-only", cwd=str(REPO_ROOT), model="kimi-k3-high"),
+        "/tmp/p.md",
+        [],
+    )
+    assert argv[0] == "cursor-agent", argv
+    assert Path(argv[0]).name != "sandbox-exec", argv
+    for flag in _CURSOR_REFUSED_SANDBOX_FLAGS:
+        assert flag not in argv, (flag, argv)
+    assert argv[argv.index("--model") + 1] == "kimi-k3-high", argv
+    try:
+        d._validate_agent_os_sandbox(
+            _args(agent="cursor", shape="bash", os_sandbox="read-only", cwd=str(REPO_ROOT))
+        )
+    except d.UnsupportedAgentSandboxRequest as exc:
+        message = str(exc)
+        assert "--os-sandbox" in message, message
+        assert "agent=cursor" in message, message
+    else:
+        raise AssertionError("cursor bash --os-sandbox read-only must refuse off Darwin")
+
+
+def case_moonshot_argv_stays_unwrapped_on_darwin() -> None:
+    """Kimi-via-cursor is a cursor model; moonshot agent_id stays its own path."""
+    import tempfile
+
+    with tempfile.TemporaryDirectory(prefix="gf-moonshot-argv-") as tmp:
+        prompt = Path(tmp) / "p.md"
+        prompt.write_text("Inspect the tree.\n", encoding="utf-8")
+        with _force_darwin_sandbox_exec():
+            argv, stdin_path = d.build_worker(
+                _args(agent="moonshot", os_sandbox=None, cwd=str(REPO_ROOT)),
+                str(prompt),
+                [],
+            )
+        assert argv[:2] == ["/bin/sh", "-lc"], argv
+        assert not any(Path(part).name == "sandbox-exec" for part in argv), argv
+        assert "kimi" in argv[2], argv
+        assert stdin_path is None, stdin_path
+        d._validate_agent_os_sandbox(
+            _args(agent="moonshot", shape="bash", os_sandbox="off", cwd=str(REPO_ROOT))
+        )
+        try:
+            d._validate_agent_os_sandbox(
+                _args(
+                    agent="moonshot",
+                    shape="bash",
+                    os_sandbox="read-only",
+                    cwd=str(REPO_ROOT),
+                )
+            )
+        except d.UnsupportedAgentSandboxRequest as exc:
+            assert "supports only --os-sandbox off" in str(exc), exc
+        else:
+            raise AssertionError("moonshot --os-sandbox read-only must stay refused")
+
+
 def case_boundary_rejected_early_names_the_real_cause() -> None:
     """The sandbox refuses when cwd sits in a temp/agent-state root. Say so up front.
 
@@ -217,6 +393,9 @@ def main() -> None:
     case_claude_acp_read_only_fallback_notice_is_pinned()
     case_acp_supported_and_unrequested_warning_paths_are_unchanged()
     case_profile_survives_submit_drain()
+    case_cursor_read_only_argv_wraps_sandbox_exec_on_darwin()
+    case_cursor_read_only_argv_stays_unwrapped_off_darwin()
+    case_moonshot_argv_stays_unwrapped_on_darwin()
     case_boundary_rejected_early_names_the_real_cause()
     print("test_dispatch_os_sandbox: all cases passed")
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Controllers keep writing `--os-sandbox read-only` (and `workspace-write`). Cursor CLI has no read-only primitive, so `--agent cursor` on Darwin now uses the same `runner:sandbox-exec` Seatbelt wrap ACP already uses for grok/codex.

## Symptom
Default cursor shape is bash. `_os_sandbox_enforced_by_launch` treated bash cursor as inert and refused `--os-sandbox`. The adapter already declared `implementation: runner:sandbox-exec`, but dispatch never wrapped the argv. Kimi-via-cursor (`--model kimi-k3-high`) is the same cursor path — not a missing `moonshot` agent_id.

## Change
- Honour `--os-sandbox` for `--agent cursor` / `cursor-agent` when the adapter + platform can enforce it (Darwin).
- Wrap `cursor-agent` with `sandbox-exec` via `prepare_os_sandbox_command`. Do not pass a cursor-cli sandbox flag.
- `--os-sandbox off` stays a no-wrap honour. Linux/other hosts still refuse `read-only` / `workspace-write`.
- Moonshot (`--agent moonshot`) is unchanged (off-only).

## Tests
Hermetic Darwin mock: cursor read-only / workspace-write / `--read-only` / kimi-k3-high argv includes `sandbox-exec` and does not include `--sandbox` / `--no-sandbox` / `--os-sandbox` on the cursor-agent tail. Moonshot argv stays `/bin/sh -lc` + kimi.

No live cursor-agent network required.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-32c80ab1-f612-4dfe-a763-c311e97a3f00?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-32c80ab1-f612-4dfe-a763-c311e97a3f00&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

