### PR TITLE
Refuse unaddressed controller mail instead of recording it as delivered

### DIFF
--- a/protocols/controller-mail.md
+++ b/protocols/controller-mail.md
@@ -58,16 +58,24 @@ marker text when one was harvested — including when the watcher called the run
 
 ## Send
 
+Controller mail requires an addressee. Unaddressed posts fail closed and do not
+record an envelope — including an omitted `--to-controller` and an empty
+`addressee: {}`. `advisory` (and aliases such as `note`, `defect-notice`,
+`qa-bug`, `controller-note`) cannot carry a controller addressee; use
+`controller-notice`. Worker dispatch types (`result`, `blocked`, `ack`) stay
+keyed by `--dispatch-id` and do not need `--to-controller`.
+
 ```bash
 python3 <skill-root>/scripts/goalflight_messages.py post \
-  --dispatch-id <topic-slug> --type user_need \
+  --dispatch-id <topic-slug> --type controller-notice \
   --to-controller <label> --subject '<one scannable line>' \
   --text '<body>'
 ```
 
 `--to-controller` uses a durable label. `--controller-project-root` defaults to the
 current canonical git project and is needed only for explicit cross-project mail.
-A send that reaches nobody is not success: the CLI exits non-zero and
+Passing `--controller-project-root` without `--to-controller` does not address
+mail. A send that reaches nobody is not success: the CLI exits non-zero and
 `controller_delivery.status` is the machine-readable miss (`controller_addressee_unresolved`,
 `controller_addressee_other_project`, or `controller_registry_unknown`). When the
 label is registered in another project, that error names `--controller-project-root`

--- a/scripts/goalflight_messages.py
+++ b/scripts/goalflight_messages.py
@@ -257,6 +257,10 @@ CONTROLLER_ADDRESSEE_TYPES = CONTROLLER_CHANNEL_TYPES | frozenset(
         "finding",
     }
 )
+# advisory's lifecycle aliases that are dispatch-scoped worker mail, not
+# controller correspondence. Everything else that canonicalizes to advisory
+# is the junk drawer (note, defect-notice, qa-bug, controller-note, …).
+WORKER_SAFE_ADVISORY_ALIASES = frozenset({"ack"})
 # Removed CONTROLLER_LISTENER_ESCALATION_TYPES: its partial set was superseded by registry wake classes.
 TASK_STORE_STATUS_NUDGE_KINDS = frozenset({"parallel-ready", "resume-ready", "done-suggest"})
 NON_ERROR_UNDELIVERED_STATUSES = frozenset({"terminal_recorded_only", "worker_view_queued"})
@@ -722,7 +726,8 @@ def validate_envelope(
         ):
             raise MessageError(
                 f"{path}.addressee: controller addressing is only valid for "
-                "controller-channel types or merge-request/patch/finding"
+                "controller-channel types or merge-request/patch/finding; "
+                "use --type controller-notice with --to-controller LABEL"
             )
     return _canonical_json_text(envelope, path=path, byte_limit=MAX_ENVELOPE_JSON_BYTES)
 
@@ -1493,6 +1498,127 @@ def _reject_steer_type_off_worker_mailbox(dispatch_id: str, msg_type: str) -> No
     )
 
 
+def _worker_own_inbox_post(dispatch_id: str) -> bool:
+    """True when this process is the worker posting to its own dispatch stream."""
+    return os.environ.get("GOALFLIGHT_DISPATCH_ID") == dispatch_id
+
+
+def _is_advisory_junk_drawer_type(msg_type: str) -> bool:
+    """advisory and its controller-mail aliases; not ack or addressee types."""
+    raw = str(msg_type or "")
+    if raw in CONTROLLER_ADDRESSEE_TYPES or raw in WORKER_SAFE_ADVISORY_ALIASES:
+        return False
+    return raw == "advisory" or canonical_event_type(raw) == "advisory"
+
+
+def _is_controller_directed_post_type(msg_type: str) -> bool:
+    raw = str(msg_type or "")
+    return raw in CONTROLLER_ADDRESSEE_TYPES or canonical_event_type(raw) in CONTROLLER_CHANNEL_TYPES
+
+
+def _complete_controller_addressee(addressee: object) -> bool:
+    if not isinstance(addressee, dict) or not addressee:
+        return False
+    label = addressee.get("label")
+    root = addressee.get("project_root")
+    return (
+        addressee.get("kind") == CONTROLLER_ADDRESSEE_KIND
+        and isinstance(label, str)
+        and bool(label.strip())
+        and isinstance(root, str)
+        and bool(root.strip())
+    )
+
+
+def _controller_mail_post_syntax(*, dispatch_id: str = "<id>") -> str:
+    stream = str(dispatch_id or "").strip() or "<id>"
+    return (
+        "python3 scripts/goalflight_messages.py post "
+        f"--dispatch-id {stream} --type controller-notice "
+        "--to-controller LABEL [--controller-project-root ROOT] "
+        "--subject '...' --text '...'"
+    )
+
+
+def _unaddressed_controller_mail_error(msg_type: str, *, dispatch_id: str = "") -> MessageError:
+    """Refuse unaddressed / wrong-type controller mail with copy-pasteable syntax."""
+    syntax = _controller_mail_post_syntax(dispatch_id=dispatch_id)
+    raw = str(msg_type or "")
+    if _is_advisory_junk_drawer_type(raw):
+        return MessageError(
+            f"type {raw!r} is not delivered as controller mail; "
+            "mail with no addressee is not delivered. "
+            "Use --type controller-notice and pass --to-controller LABEL. "
+            f"Correct syntax: {syntax}"
+        )
+    return MessageError(
+        "mail with no addressee is not delivered; pass --to-controller LABEL "
+        "(and --controller-project-root when the label lives on another project). "
+        f"Correct syntax: {syntax}"
+    )
+
+
+def _reject_unaddressed_controller_mail(
+    *,
+    msg_type: str,
+    dispatch_id: str,
+    addressee: object,
+    payload: object,
+    deliver_to_worker: bool,
+    project_journal_delivery: bool,
+) -> None:
+    """Fail closed before any carrier/journal write.
+
+    CLI controller mail and a Python caller that would record into nowhere
+    both raise MessageError. Worker dispatch types are not this path.
+    ``deliver_to_worker`` and a worker posting to its own inbox stay open.
+    Library omitted addressee on a controller type is allowed only when
+    journal targeting already has a recipient (dispatch owner or payload root).
+    Empty ``{}`` is never a recipient.
+    """
+    if _is_advisory_junk_drawer_type(msg_type):
+        if addressee is not None:
+            raise _unaddressed_controller_mail_error(msg_type, dispatch_id=dispatch_id)
+        return
+    if not _is_controller_directed_post_type(msg_type):
+        return
+    if _complete_controller_addressee(addressee):
+        return
+    if addressee is not None:
+        raise _unaddressed_controller_mail_error(msg_type, dispatch_id=dispatch_id)
+    if deliver_to_worker or _worker_own_inbox_post(dispatch_id):
+        return
+    if not project_journal_delivery:
+        raise _unaddressed_controller_mail_error(msg_type, dispatch_id=dispatch_id)
+    probe = {
+        "dispatch_id": dispatch_id,
+        "type": msg_type,
+        "payload": payload if isinstance(payload, dict) else {},
+    }
+    try:
+        targets = _journal_delivery_targets(probe)
+    except MessageError:
+        raise _unaddressed_controller_mail_error(msg_type, dispatch_id=dispatch_id) from None
+    if not targets:
+        raise _unaddressed_controller_mail_error(msg_type, dispatch_id=dispatch_id)
+
+
+def _reject_cli_unaddressed_controller_mail(args: argparse.Namespace) -> None:
+    """CLI ``post`` requires ``--to-controller`` for controller-directed types."""
+    msg_type = str(getattr(args, "type", "") or "")
+    dispatch_id = str(getattr(args, "dispatch_id", "") or "")
+    to_controller = getattr(args, "to_controller", None)
+    if _is_advisory_junk_drawer_type(msg_type):
+        raise _unaddressed_controller_mail_error(msg_type, dispatch_id=dispatch_id)
+    if to_controller:
+        return
+    if not _is_controller_directed_post_type(msg_type):
+        return
+    if _worker_own_inbox_post(dispatch_id):
+        return
+    raise _unaddressed_controller_mail_error(msg_type, dispatch_id=dispatch_id)
+
+
 def post_message(
     *,
     dispatch_id: str,
@@ -1516,6 +1642,14 @@ def post_message(
 ) -> dict:
     """Admit one monotonic stream envelope; shared by CLI, MCP, and tests."""
     _reject_steer_type_off_worker_mailbox(dispatch_id, msg_type)
+    _reject_unaddressed_controller_mail(
+        msg_type=msg_type,
+        dispatch_id=dispatch_id,
+        addressee=addressee,
+        payload=payload,
+        deliver_to_worker=deliver_to_worker,
+        project_journal_delivery=project_journal_delivery,
+    )
     validate_payload(payload)
     try:
         import goalflight_output_redact
@@ -2778,6 +2912,7 @@ def cmd_from_text(args: argparse.Namespace) -> int:
 
 def cmd_post(args: argparse.Namespace) -> int:
     to_controller = getattr(args, "to_controller", None)
+    _reject_cli_unaddressed_controller_mail(args)
     try:
         payload = json.loads(args.payload) if args.payload else {"text": args.text or ""}
     except (ValueError, RecursionError) as exc:
@@ -8412,7 +8547,13 @@ def _run_cli(argv: list[str] | None = None) -> int:
     post.add_argument(
         "--to-controller",
         metavar="LABEL",
-        help="address controller-channel mail to one durable controller registry name",
+        help=(
+            "required addressee for controller-channel mail and "
+            "merge-request/patch/finding. Unaddressed controller mail is "
+            "refused and not recorded. advisory and aliases such as note, "
+            "defect-notice, qa-bug, or controller-note cannot be addressed; "
+            "use --type controller-notice"
+        ),
     )
     post.add_argument(
         "--controller-project-root",

--- a/scripts/goalflight_messages.py
+++ b/scripts/goalflight_messages.py
@@ -1530,6 +1530,11 @@ def _complete_controller_addressee(addressee: object) -> bool:
     )
 
 
+def _addressee_is_missing(addressee: object) -> bool:
+    """Omitted, null, and empty/incomplete ``{}`` are the same missing address."""
+    return not _complete_controller_addressee(addressee)
+
+
 def _controller_mail_post_syntax(*, dispatch_id: str = "<id>") -> str:
     stream = str(dispatch_id or "").strip() or "<id>"
     return (
@@ -1567,55 +1572,35 @@ def _reject_unaddressed_controller_mail(
     deliver_to_worker: bool,
     project_journal_delivery: bool,
 ) -> None:
-    """Fail closed before any carrier/journal write.
+    """One pre-write gate: missing addressee is omitted, null, or ``{}``.
 
-    CLI controller mail and a Python caller that would record into nowhere
-    both raise MessageError. Worker dispatch types are not this path.
+    Worker ``result``/``blocked``/``ack`` never enter this path.
     ``deliver_to_worker`` and a worker posting to its own inbox stay open.
-    Library omitted addressee on a controller type is allowed only when
-    journal targeting already has a recipient (dispatch owner or payload root).
-    Empty ``{}`` is never a recipient.
+    Success means a journal recipient already exists (explicit addressee or
+    an implicit dispatch-owner / payload-root target). Otherwise refuse.
+    ``advisory`` and junk-drawer aliases cannot be addressed; an omitted
+    library advisory (quota / MCP) is not controller mail.
     """
+    missing = _addressee_is_missing(addressee)
     if _is_advisory_junk_drawer_type(msg_type):
-        if addressee is not None:
-            raise _unaddressed_controller_mail_error(msg_type, dispatch_id=dispatch_id)
-        return
-    if not _is_controller_directed_post_type(msg_type):
-        return
-    if _complete_controller_addressee(addressee):
-        return
-    if addressee is not None:
+        if missing and addressee is None:
+            return
         raise _unaddressed_controller_mail_error(msg_type, dispatch_id=dispatch_id)
+    if not _is_controller_directed_post_type(msg_type) or not missing:
+        return
     if deliver_to_worker or _worker_own_inbox_post(dispatch_id):
         return
-    if not project_journal_delivery:
-        raise _unaddressed_controller_mail_error(msg_type, dispatch_id=dispatch_id)
-    probe = {
-        "dispatch_id": dispatch_id,
-        "type": msg_type,
-        "payload": payload if isinstance(payload, dict) else {},
-    }
-    try:
-        targets = _journal_delivery_targets(probe)
-    except MessageError:
-        raise _unaddressed_controller_mail_error(msg_type, dispatch_id=dispatch_id) from None
-    if not targets:
-        raise _unaddressed_controller_mail_error(msg_type, dispatch_id=dispatch_id)
-
-
-def _reject_cli_unaddressed_controller_mail(args: argparse.Namespace) -> None:
-    """CLI ``post`` requires ``--to-controller`` for controller-directed types."""
-    msg_type = str(getattr(args, "type", "") or "")
-    dispatch_id = str(getattr(args, "dispatch_id", "") or "")
-    to_controller = getattr(args, "to_controller", None)
-    if _is_advisory_junk_drawer_type(msg_type):
-        raise _unaddressed_controller_mail_error(msg_type, dispatch_id=dispatch_id)
-    if to_controller:
-        return
-    if not _is_controller_directed_post_type(msg_type):
-        return
-    if _worker_own_inbox_post(dispatch_id):
-        return
+    if project_journal_delivery:
+        probe = {
+            "dispatch_id": dispatch_id,
+            "type": msg_type,
+            "payload": payload if isinstance(payload, dict) else {},
+        }
+        try:
+            if _journal_delivery_targets(probe):
+                return
+        except MessageError:
+            pass
     raise _unaddressed_controller_mail_error(msg_type, dispatch_id=dispatch_id)
 
 
@@ -1650,6 +1635,8 @@ def post_message(
         deliver_to_worker=deliver_to_worker,
         project_journal_delivery=project_journal_delivery,
     )
+    if addressee is not None and _addressee_is_missing(addressee):
+        addressee = None
     validate_payload(payload)
     try:
         import goalflight_output_redact
@@ -2912,7 +2899,12 @@ def cmd_from_text(args: argparse.Namespace) -> int:
 
 def cmd_post(args: argparse.Namespace) -> int:
     to_controller = getattr(args, "to_controller", None)
-    _reject_cli_unaddressed_controller_mail(args)
+    if _is_advisory_junk_drawer_type(args.type) or (
+        not to_controller
+        and _is_controller_directed_post_type(args.type)
+        and not _worker_own_inbox_post(args.dispatch_id)
+    ):
+        raise _unaddressed_controller_mail_error(args.type, dispatch_id=args.dispatch_id)
     try:
         payload = json.loads(args.payload) if args.payload else {"text": args.text or ""}
     except (ValueError, RecursionError) as exc:
@@ -3008,9 +3000,9 @@ def cmd_post(args: argparse.Namespace) -> int:
             addressee=addressee,
             fleet_dir=args.fleet_dir,
             update_aggregate=args.refresh_aggregate,
-            deliver_to_worker=(
-                addressee is None and _controller_delivery_requested(args.dispatch_id, args.type)
-            ),
+            # CLI controller mail is journal-addressed. Worker views are the
+            # library / MCP deliver_to_worker path, not an unaddressed post.
+            deliver_to_worker=False,
         )
     except MessageError as exc:
         if not to_controller:

--- a/tests/python/test_goalflight_messages.py
+++ b/tests/python/test_goalflight_messages.py
@@ -187,6 +187,7 @@ def _journal_test_env(base: Path) -> dict[str, str]:
         "GOALFLIGHT_MESSAGES_DIR": str(base / "messages"),
         "GOALFLIGHT_FLEET_DIR": str(base / "fleet"),
         "GOALFLIGHT_STATE_DIR": str(base / "state"),
+        "GOALFLIGHT_DISPATCH_DIR": str(base / "state" / "dispatch"),
         "GOALFLIGHT_WAKE_LEDGER_DIR": str(base / "wake-ledger"),
         "GOAL_FLIGHT_PIDFILE_DIR": str(base / "pids"),
         "GOALFLIGHT_CAPACITY_CONF": os.devnull,
@@ -1331,31 +1332,22 @@ def test_controller_post_reaches_worker_steer_read_path() -> None:
     with tempfile.TemporaryDirectory() as td:
         base = Path(td)
         messages_dir = base / "messages"
-        fleet_dir = base / "fleet"
         dispatch_id = "d-controller-live"
-        write_ledger_record(base, dispatch_id, base / "project", state="running", worker_pid=os.getpid())
-        steer_path = steer.steer_file(dispatch_id, state_dir=base / "state")
-        steer.append_steer_entry(steer_path, "earlier steer", dispatch_id=dispatch_id)
+        with mock.patch.dict(os.environ, _journal_test_env(base), clear=False):
+            write_ledger_record(base, dispatch_id, base / "project", state="running", worker_pid=os.getpid())
+            steer_path = steer.steer_file(dispatch_id, state_dir=base / "state")
+            steer.append_steer_entry(steer_path, "earlier steer", dispatch_id=dispatch_id)
+            result = _carrier_messages.post_message(
+                dispatch_id=dispatch_id,
+                msg_type="controller-notice",
+                payload={"text": "worker-visible notice"},
+                messages_dir=messages_dir,
+                deliver_to_worker=True,
+            )
 
-        posted = run_messages_cli(
-            messages_dir,
-            fleet_dir,
-            [
-                "post",
-                "--dispatch-id",
-                dispatch_id,
-                "--type",
-                "controller-notice",
-                "--text",
-                "worker-visible notice",
-            ],
-        )
-
-        assert_true(f"controller post succeeds: {posted.stderr}", posted.returncode == 0)
-        result = json.loads(posted.stdout)
-        assert_true("record is reported", result["recorded"] is True)
-        assert_true("worker delivery is reported", result["delivery"]["delivered"] is True)
-        entries = steer.worker_entries(steer.read_steer_entries(steer_path))
+            assert_true("record is reported", result["recorded"] is True)
+            assert_true("worker delivery is reported", result["delivery"]["delivered"] is True)
+            entries = steer.worker_entries(steer.read_steer_entries(steer_path))
         delivered = entries[-1]
         assert_true("worker read path sees posted text", delivered["text"] == "worker-visible notice")
         assert_true("steer sequence remains independent", delivered["seq"] == 2)
@@ -1666,26 +1658,18 @@ def test_worker_delivery_post_report_shape_is_unchanged() -> None:
     with tempfile.TemporaryDirectory() as td:
         base = Path(td)
         messages_dir = base / "messages"
-        fleet_dir = base / "fleet"
         dispatch_id = "worker-report-shape"
         write_ledger_record(base, dispatch_id, base / "project", state="running", worker_pid=os.getpid())
 
-        posted = run_messages_cli(
-            messages_dir,
-            fleet_dir,
-            [
-                "post",
-                "--dispatch-id",
-                dispatch_id,
-                "--type",
-                "controller-notice",
-                "--text",
-                "worker channel only",
-            ],
-        )
+        with mock.patch.dict(os.environ, _journal_test_env(base), clear=False):
+            result = _carrier_messages.post_message(
+                dispatch_id=dispatch_id,
+                msg_type="controller-notice",
+                payload={"text": "worker channel only"},
+                messages_dir=messages_dir,
+                deliver_to_worker=True,
+            )
 
-        assert_true(f"worker delivery succeeds: {posted.stderr}", posted.returncode == 0)
-        result = json.loads(posted.stdout)
         assert_true(
             "worker post top-level report shape is unchanged",
             set(result) == {"envelope", "line", "path", "recorded", "delivery"},
@@ -1812,25 +1796,27 @@ def test_controller_channel_types_project_and_remain_in_aggregate() -> None:
         fleet_dir.mkdir()
         write_ledger_record(base, dispatch_id, base / "project", state="running", worker_pid=os.getpid())
 
-        for msg_type in sorted(expected_types):
-            posted = run_messages_cli(
-                messages_dir,
-                fleet_dir,
-                ["post", "--dispatch-id", dispatch_id, "--type", msg_type, "--text", msg_type],
+        with mock.patch.dict(os.environ, _journal_test_env(base), clear=False):
+            for msg_type in sorted(expected_types):
+                posted = _carrier_messages.post_message(
+                    dispatch_id=dispatch_id,
+                    msg_type=msg_type,
+                    payload={"text": msg_type},
+                    messages_dir=messages_dir,
+                    deliver_to_worker=True,
+                )
+                assert_true(f"{msg_type} reaches worker", posted["recorded"] is True)
+            entries = steer.worker_entries(
+                steer.read_steer_entries(steer.steer_file(dispatch_id, state_dir=base / "state"))
             )
-            assert_true(f"{msg_type} reaches worker: {posted.stderr}", posted.returncode == 0)
-
-        entries = steer.worker_entries(
-            steer.read_steer_entries(steer.steer_file(dispatch_id, state_dir=base / "state"))
-        )
-        projected_types = {
-            entry["context"]["message_envelope"]["type"]
-            for entry in entries
-        }
-        assert_true("every controller channel type projects", projected_types == expected_types)
-        aggregate = build_aggregate(messages_dir=messages_dir, fleet_dir=fleet_dir)
-        aggregate_types = {item["type"] for item in aggregate["open_controller_channel"]}
-        assert_true("every projected type remains relay-visible", aggregate_types == expected_types)
+            projected_types = {
+                entry["context"]["message_envelope"]["type"]
+                for entry in entries
+            }
+            assert_true("every controller channel type projects", projected_types == expected_types)
+            aggregate = build_aggregate(messages_dir=messages_dir, fleet_dir=fleet_dir)
+            aggregate_types = {item["type"] for item in aggregate["open_controller_channel"]}
+            assert_true("every projected type remains relay-visible", aggregate_types == expected_types)
 
 
 def test_concurrent_controller_posts_preserve_worker_view_order() -> None:
@@ -1926,26 +1912,22 @@ def test_live_controller_post_delivery_failure_is_nonzero_and_recorded() -> None
         blocked_steer_path = base / "state" / "dispatch" / f"{dispatch_id}.steer.jsonl"
         blocked_steer_path.mkdir(parents=True)
 
-        posted = run_messages_cli(
-            messages_dir,
-            fleet_dir,
-            [
-                "post",
-                "--dispatch-id",
-                dispatch_id,
-                "--type",
-                "controller-notice",
-                "--text",
-                "record even when delivery fails",
-            ],
-        )
+        with mock.patch.dict(os.environ, _journal_test_env(base), clear=False):
+            result = _carrier_messages.post_message(
+                dispatch_id=dispatch_id,
+                msg_type="controller-notice",
+                payload={"text": "record even when delivery fails"},
+                messages_dir=messages_dir,
+                deliver_to_worker=True,
+            )
 
-        assert_true("undeliverable live post is nonzero", posted.returncode != 0)
-        result = json.loads(posted.stdout)
         assert_true("failed delivery still reports record", result["recorded"] is True)
         assert_true("failed delivery is explicit", result["delivery"]["status"] == "worker_delivery_failed")
         assert_true("failed delivery is not claimed", result["delivery"]["delivered"] is False)
-        assert_true("call site says record versus delivery", "recorded but worker delivery failed" in posted.stderr)
+        assert_true(
+            "call site says record versus delivery",
+            "recorded but worker delivery failed" in result["delivery"]["detail"],
+        )
         envelopes = read_envelopes(messages_dir / f"{dispatch_id}.jsonl")
         assert_true(
             "record survives delivery failure",
@@ -1964,22 +1946,15 @@ def test_running_label_without_live_identity_is_not_delivery() -> None:
         dispatch_id = "d-controller-no-worker"
         write_ledger_record(base, dispatch_id, base / "project", state="running")
 
-        posted = run_messages_cli(
-            messages_dir,
-            fleet_dir,
-            [
-                "post",
-                "--dispatch-id",
-                dispatch_id,
-                "--type",
-                "controller-notice",
-                "--text",
-                "do not call a state label delivery",
-            ],
-        )
+        with mock.patch.dict(os.environ, _journal_test_env(base), clear=False):
+            result = _carrier_messages.post_message(
+                dispatch_id=dispatch_id,
+                msg_type="controller-notice",
+                payload={"text": "do not call a state label delivery"},
+                messages_dir=messages_dir,
+                deliver_to_worker=True,
+            )
 
-        assert_true("running label without worker is nonzero", posted.returncode != 0)
-        result = json.loads(posted.stdout)
         assert_true("message remains recorded", result["recorded"] is True)
         assert_true("no worker delivery is claimed", result["delivery"]["delivered"] is False)
         assert_true("missing worker identity is explicit", result["delivery"]["dispatch_classification"] == "unknown_no_pid")
@@ -2005,22 +1980,15 @@ def test_detached_controller_dead_record_with_live_worker_still_delivers() -> No
             reason="controller_dead",
         )
 
-        posted = run_messages_cli(
-            messages_dir,
-            fleet_dir,
-            [
-                "post",
-                "--dispatch-id",
-                dispatch_id,
-                "--type",
-                "controller-notice",
-                "--text",
-                "detached worker still owns this mailbox",
-            ],
-        )
+        with mock.patch.dict(os.environ, _journal_test_env(base), clear=False):
+            result = _carrier_messages.post_message(
+                dispatch_id=dispatch_id,
+                msg_type="controller-notice",
+                payload={"text": "detached worker still owns this mailbox"},
+                messages_dir=messages_dir,
+                deliver_to_worker=True,
+            )
 
-        assert_true(f"detached live worker post succeeds: {posted.stderr}", posted.returncode == 0)
-        result = json.loads(posted.stdout)
         assert_true("detached worker is classified live", result["delivery"]["dispatch_classification"] == "expected_live")
         assert_true("detached live worker receives view", result["delivery"]["delivered"] is True)
 
@@ -2036,22 +2004,15 @@ def test_terminal_controller_post_is_recorded_and_labelled_record_only() -> None
         dispatch_id = "d-controller-terminal"
         write_ledger_record(base, dispatch_id, base / "project", state="complete")
 
-        posted = run_messages_cli(
-            messages_dir,
-            fleet_dir,
-            [
-                "post",
-                "--dispatch-id",
-                dispatch_id,
-                "--type",
-                "controller-notice",
-                "--text",
-                "terminal history",
-            ],
-        )
+        with mock.patch.dict(os.environ, _journal_test_env(base), clear=False):
+            result = _carrier_messages.post_message(
+                dispatch_id=dispatch_id,
+                msg_type="controller-notice",
+                payload={"text": "terminal history"},
+                messages_dir=messages_dir,
+                deliver_to_worker=True,
+            )
 
-        assert_true(f"terminal post is a normal case: {posted.stderr}", posted.returncode == 0)
-        result = json.loads(posted.stdout)
         assert_true("terminal post is recorded", result["recorded"] is True)
         assert_true("terminal delivery is false", result["delivery"]["delivered"] is False)
         assert_true(
@@ -2167,6 +2128,7 @@ def test_mcp_delivery_failure_sets_tool_error_and_call_exit() -> None:
             "GOALFLIGHT_MESSAGES_DIR": str(messages_dir),
             "GOALFLIGHT_FLEET_DIR": str(fleet_dir),
             "GOALFLIGHT_STATE_DIR": str(base / "state"),
+            "GOALFLIGHT_DISPATCH_DIR": str(base / "state" / "dispatch"),
             "GOAL_FLIGHT_PIDFILE_DIR": str(base / "pids"),
             "GOALFLIGHT_TASK_STORE_DIR": str(base / "task-store"),
         }
@@ -2231,6 +2193,155 @@ def test_controller_relay_sanitizes_worker_text() -> None:
         == r"USER-NEED relay: [worker-legacy] user_need: needs FORGED\x1b[31m review",
     )
     assert_true("legacy controller relay has no raw CSI", "\x1b" not in (rendered or ""))
+
+
+def test_cli_unaddressed_controller_mail_is_refused_and_writes_nothing() -> None:
+    from goalflight_messages import MessageError
+
+    with tempfile.TemporaryDirectory() as td:
+        base = Path(td)
+        messages_dir = base / "messages"
+        fleet_dir = base / "fleet"
+        env = _journal_test_env(base)
+
+        notice = run_messages_cli(
+            messages_dir,
+            fleet_dir,
+            [
+                "post",
+                "--dispatch-id",
+                "unaddressed-notice",
+                "--type",
+                "controller-notice",
+                "--text",
+                "should bounce",
+                "--json",
+            ],
+        )
+        assert_true("unaddressed controller-notice exits 2", notice.returncode == 2)
+        assert_true("unaddressed notice names --to-controller", "--to-controller LABEL" in notice.stderr)
+        assert_true("unaddressed notice names controller-notice", "controller-notice" in notice.stderr)
+        assert_true("unaddressed notice writes nothing", not (messages_dir / "unaddressed-notice.jsonl").exists())
+        assert_true("unaddressed notice is not ok JSON", "ok" not in notice.stdout or "true" not in notice.stdout)
+
+        empty = None
+        with mock.patch.dict(os.environ, env, clear=False):
+            try:
+                _carrier_messages.post_message(
+                    dispatch_id="empty-addressee",
+                    msg_type="controller-notice",
+                    payload={"text": "empty object"},
+                    messages_dir=messages_dir,
+                    addressee={},
+                )
+            except MessageError as exc:
+                empty = exc
+        assert_true("empty addressee raises", empty is not None)
+        assert_true("empty addressee names --to-controller", "--to-controller LABEL" in str(empty))
+        assert_true("empty addressee writes nothing", not (messages_dir / "empty-addressee.jsonl").exists())
+
+        advisory = run_messages_cli(
+            messages_dir,
+            fleet_dir,
+            [
+                "post",
+                "--dispatch-id",
+                "advisory-nowhere",
+                "--type",
+                "advisory",
+                "--text",
+                "bug report",
+                "--json",
+            ],
+        )
+        assert_true("advisory CLI exits 2", advisory.returncode == 2)
+        assert_true("advisory names --to-controller", "--to-controller LABEL" in advisory.stderr)
+        assert_true("advisory names controller-notice", "--type controller-notice" in advisory.stderr)
+        assert_true("advisory writes nothing", not (messages_dir / "advisory-nowhere.jsonl").exists())
+        assert_true("advisory JSON is not ok:true", '"ok"' not in advisory.stdout)
+
+        for junk in ("note", "defect-notice", "qa-bug", "controller-note"):
+            posted = run_messages_cli(
+                messages_dir,
+                fleet_dir,
+                ["post", "--dispatch-id", f"junk-{junk}", "--type", junk, "--text", "nope"],
+            )
+            assert_true(f"{junk} CLI exits 2", posted.returncode == 2)
+            assert_true(f"{junk} names controller-notice", "controller-notice" in posted.stderr)
+            assert_true(f"{junk} names --to-controller", "--to-controller LABEL" in posted.stderr)
+            assert_true(f"{junk} writes nothing", not (messages_dir / f"junk-{junk}.jsonl").exists())
+
+
+def test_cli_addressed_controller_notice_still_succeeds() -> None:
+    import goalflight_journal
+
+    with tempfile.TemporaryDirectory() as td:
+        base = Path(td)
+        project = base / "project"
+        init_git_project(project)
+        messages_dir = base / "messages"
+        fleet_dir = base / "fleet"
+        label = "addressed-controller"
+        env = _journal_test_env(base)
+        with mock.patch.dict(os.environ, env, clear=False):
+            authority = goalflight_journal.open_or_create_journal(project)
+            claimed = authority.claim_or_renew_lease(
+                label,
+                principal={"principal_id": "addressed-post-test"},
+            )
+            assert_true("addressed controller lease claimed", claimed.committed)
+            posted = run_messages_cli(
+                messages_dir,
+                fleet_dir,
+                [
+                    "post",
+                    "--dispatch-id",
+                    "addressed-notice",
+                    "--type",
+                    "controller-notice",
+                    "--text",
+                    "reaches the label",
+                    "--to-controller",
+                    label,
+                    "--controller-project-root",
+                    str(project),
+                    "--json",
+                ],
+            )
+            assert_true(f"addressed controller-notice succeeds: {posted.stderr}", posted.returncode == 0)
+            result = json.loads(posted.stdout)
+            assert_true("addressed post is recorded", result["recorded"] is True)
+            assert_true("addressed delivery status", result["controller_delivery"]["status"] == "delivered_to_controller")
+
+
+def test_cli_worker_result_blocked_ack_without_to_controller_still_succeed() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        base = Path(td)
+        messages_dir = base / "messages"
+        fleet_dir = base / "fleet"
+        for msg_type, dispatch_id in (
+            ("result", "worker-result"),
+            ("blocked", "worker-blocked"),
+            ("ack", "worker-ack"),
+        ):
+            posted = run_messages_cli(
+                messages_dir,
+                fleet_dir,
+                [
+                    "post",
+                    "--dispatch-id",
+                    dispatch_id,
+                    "--type",
+                    msg_type,
+                    "--text",
+                    f"{msg_type} from worker",
+                    "--json",
+                ],
+            )
+            assert_true(f"{msg_type} worker post succeeds: {posted.stderr}", posted.returncode == 0)
+            result = json.loads(posted.stdout)
+            assert_true(f"{msg_type} is recorded", result["recorded"] is True)
+            assert_true(f"{msg_type} wrote a carrier", (messages_dir / f"{dispatch_id}.jsonl").is_file())
 
 
 def test_bounded_relay_sanitizes_c1_csi() -> None:

--- a/tests/python/test_goalflight_p2.py
+++ b/tests/python/test_goalflight_p2.py
@@ -932,6 +932,28 @@ def test_d13_registry_is_exhaustive_and_cli_mcp_compatible(
             env["GOALFLIGHT_MESSAGES_DIR"],
             "post",
             "--dispatch-id",
+            "cli-status",
+            "--type",
+            "status",
+            "--text",
+            "CLI status",
+            "--json",
+        ],
+        cwd=tmp_path,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert cli.returncode == 0, cli.stderr
+    advisory_cli = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPTS / "goalflight_messages.py"),
+            "--messages-dir",
+            env["GOALFLIGHT_MESSAGES_DIR"],
+            "post",
+            "--dispatch-id",
             "cli-advisory",
             "--type",
             "advisory",
@@ -945,7 +967,10 @@ def test_d13_registry_is_exhaustive_and_cli_mcp_compatible(
         capture_output=True,
         check=False,
     )
-    assert cli.returncode == 0, cli.stderr
+    assert advisory_cli.returncode == 2
+    assert "--to-controller LABEL" in advisory_cli.stderr
+    assert "--type controller-notice" in advisory_cli.stderr
+    assert not messages.inbox_path(messages.default_messages_dir(), "cli-advisory").is_file()
     mcp = mcp_messages.handle_request(
         {
             "jsonrpc": "2.0",
@@ -963,7 +988,7 @@ def test_d13_registry_is_exhaustive_and_cli_mcp_compatible(
         messages_dir=messages.default_messages_dir(),
     )
     assert "result" in mcp and "error" not in mcp
-    assert messages.inbox_path(messages.default_messages_dir(), "cli-advisory").is_file()
+    assert messages.inbox_path(messages.default_messages_dir(), "cli-status").is_file()
     assert messages.inbox_path(messages.default_messages_dir(), "mcp-advisory").is_file()
 
     legacy_cli = subprocess.run(
@@ -987,7 +1012,9 @@ def test_d13_registry_is_exhaustive_and_cli_mcp_compatible(
         capture_output=True,
         check=False,
     )
-    assert legacy_cli.returncode == 0, legacy_cli.stderr
+    assert legacy_cli.returncode == 2
+    assert "--type controller-notice" in legacy_cli.stderr
+    assert not messages.inbox_path(messages.default_messages_dir(), "cli-legacy").is_file()
     legacy_mcp = mcp_messages.handle_request(
         {
             "jsonrpc": "2.0",

--- a/tests/python/test_mail_carries_payload.py
+++ b/tests/python/test_mail_carries_payload.py
@@ -710,7 +710,7 @@ def test_merge_request_can_address_a_controller(
     )
     assert envelope["type"] == "merge-request"
     assert envelope["addressee"]["label"] == label
-    with pytest.raises(messages.MessageError, match="controller addressing"):
+    with pytest.raises(messages.MessageError, match="controller-notice"):
         messages.post_message(
             dispatch_id="nope",
             msg_type="advisory",

--- a/tests/python/test_post_to_controller_addressing.py
+++ b/tests/python/test_post_to_controller_addressing.py
@@ -481,3 +481,125 @@ def test_nonzero_to_controller_json_statuses_are_distinct(
     assert rows[4] == (2, "controller_post_usage", False)
     statuses = [row[1] for row in rows]
     assert len(set(statuses)) == len(statuses)
+
+
+def test_cli_controller_notice_without_to_controller_writes_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    env = _isolate(monkeypatch, tmp_path)
+    project = _git_project(tmp_path / "project")
+    posted = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--messages-dir",
+            env["GOALFLIGHT_MESSAGES_DIR"],
+            "--fleet-dir",
+            env["GOALFLIGHT_FLEET_DIR"],
+            "post",
+            "--dispatch-id",
+            "missing-addressee",
+            "--type",
+            "controller-notice",
+            "--text",
+            "nowhere",
+            "--json",
+        ],
+        cwd=str(project),
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert posted.returncode == 2, posted.stderr
+    assert "post: refused:" in posted.stderr
+    assert "--to-controller LABEL" in posted.stderr
+    assert "--type controller-notice" in posted.stderr
+    assert "ok" not in posted.stdout
+    inbox = Path(env["GOALFLIGHT_MESSAGES_DIR"]) / "missing-addressee.jsonl"
+    assert not inbox.exists()
+
+
+def test_library_empty_addressee_is_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    env = _isolate(monkeypatch, tmp_path)
+    messages_dir = Path(env["GOALFLIGHT_MESSAGES_DIR"])
+    with pytest.raises(messages.MessageError, match="--to-controller LABEL") as raised:
+        messages.post_message(
+            dispatch_id="empty-object",
+            msg_type="controller-coordination",
+            payload={"text": "empty addressee"},
+            messages_dir=messages_dir,
+            addressee={},
+        )
+    assert "--type controller-notice" in str(raised.value)
+    assert not (messages_dir / "empty-object.jsonl").exists()
+
+
+def test_cli_advisory_and_junk_aliases_name_controller_notice(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    env = _isolate(monkeypatch, tmp_path)
+    project = _git_project(tmp_path / "project")
+    for msg_type in ("advisory", "note", "controller-note", "defect-notice"):
+        posted = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--messages-dir",
+                env["GOALFLIGHT_MESSAGES_DIR"],
+                "post",
+                "--dispatch-id",
+                "topic-slug",
+                "--type",
+                msg_type,
+                "--text",
+                "should bounce",
+                "--json",
+            ],
+            cwd=str(project),
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert posted.returncode == 2, posted.stderr
+        assert "--to-controller LABEL" in posted.stderr
+        assert "--type controller-notice" in posted.stderr
+        syntax = posted.stderr.split("Correct syntax:", 1)[-1]
+        assert "--type controller-notice" in syntax
+        assert "controller-note" not in syntax
+        assert not (Path(env["GOALFLIGHT_MESSAGES_DIR"]) / "topic-slug.jsonl").exists()
+
+
+def test_cli_worker_result_without_to_controller_still_records(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    env = _isolate(monkeypatch, tmp_path)
+    project = _git_project(tmp_path / "project")
+    posted = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--messages-dir",
+            env["GOALFLIGHT_MESSAGES_DIR"],
+            "post",
+            "--dispatch-id",
+            "worker-result",
+            "--type",
+            "result",
+            "--text",
+            "complete",
+            "--json",
+        ],
+        cwd=str(project),
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert posted.returncode == 0, posted.stderr
+    result = json.loads(posted.stdout)
+    assert result["recorded"] is True
+    assert (Path(env["GOALFLIGHT_MESSAGES_DIR"]) / "worker-result.jsonl").is_file()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Controller `post` with no addressee currently records an envelope, delivers to nobody, and still looks successful. A live send of `--type advisory` without `--to-controller` (and the empty `addressee: {}` form) is the incident shape.

## Change
- One pre-write gate: omitted, null, and empty `{}` are the same missing addressee. Fail closed in CLI `post` and library `post_message` before any carrier/journal write.
- CLI requires `--to-controller` for controller-channel / addressee types (cmd_post). A worker posting to its own `GOALFLIGHT_DISPATCH_ID` inbox is the one exemption. CLI no longer treats an unaddressed controller-channel type as worker delivery.
- `advisory` and junk-drawer aliases (`note`, `defect-notice`, `qa-bug`, `controller-note`, …) are refused. The error names `controller-notice` and `--to-controller LABEL` with copy-pasteable syntax. Addressing is **not** added for `advisory`. `CONTROLLER_ADDRESSEE_TYPES` is unchanged. `controller-note` is not recommended.
- Worker `result` / `blocked` / `ack` posts still succeed without `--to-controller`.
- Library worker delivery (`deliver_to_worker=True`) stays open. System `advisory` writers (quota stuck, MCP) with no addressee stay open; an addressee on those types still bounces.
- Docs: `protocols/controller-mail.md` and CLI `--help` say controller mail requires `--to-controller` and that unaddressed posts are not recorded.

## Tests
Hermetic unit tests only. Cover CLI controller-notice without `--to-controller` (nothing written), empty `{}` addressee, `--type advisory` / junk aliases naming `controller-notice` + `--to-controller`, addressed `--to-controller` still succeeding, and worker `result`/`blocked`/`ack` without `--to-controller`.

## Leftovers (not this PR)
- `post --type` is still the huge D13 enum (`EVENT_TYPE_REGISTRY` plus every compatibility alias). This patch only refuses the junk drawer when used as controller mail; it does not delete aliases or split the enum.
- Relay/post flag asymmetry remains: `relay` is recipient-cursor mail, `post` still takes a free-form `--type` plus optional `--to-controller`. Tightening argparse `required` on `--to-controller` would break worker-own-inbox `controller-question` and worker `result`/`blocked`/`ack`, so the requirement stays a cmd_post type check.
- `goalflight_messages.py` is still one large module. No split.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-45116b38-afb8-401d-9db5-0c6cdfb05d69?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45116b38-afb8-401d-9db5-0c6cdfb05d69&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

