### PR TITLE
Stop the wake-pool feedback loop: unreadable ≠ dead, listener-slots is a ceiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,13 @@ incremented when meaningful skill behaviour changes.
 
 ### Fixed
 
+- Wake-pool contention loop: unreadable follow/journal state is no longer
+  treated as `listener-dead` with `backup_required` / `rearm_command`.
+  `--listener-slots` is a live-depth ceiling again; extras that would
+  exceed the cap fail closed as contention protection, not a ring.
+  `supervise` still only respawns its configured slots (it does not
+  mint extra backups from a `listener-dead` passthrough). Before acting
+  on `listener-dead`, positive control is `relay --new`.
 - `goalflight_dispatch.py resume` reattaches to the existing worktree instead
   of acquiring a sibling pooled seat, so quota-exhausted / dead / plan-approval
   pauses continue in place. `--account` is honored; default seat order skips

--- a/docs/EVENT-ARCHITECTURE.md
+++ b/docs/EVENT-ARCHITECTURE.md
@@ -425,7 +425,8 @@ and emits `event`/`listener-dead` when state is stale, faulted, missing, or inva
 The decomposed unsupervised path includes the exact re-arm command; under `supervise`
 the record keeps the reason but omits that action, and recovery is a supervisor restart.
 Unreadable follow state is not death: do not arm another doorbell on
-`journal-unavailable` / `journal-io-failure` / busy / vanished-witness. Before
+`journal-unavailable` / `journal-io-failure` / busy / vanished-witness /
+`monitor-state-io`. Before
 acting on `listener-dead`, take positive control with `relay --new` (does a new
 event round-trip, is mail arriving). If inbound coverage is intact, it is
 contention. The watchdog never claims a delivery slot or

--- a/docs/EVENT-ARCHITECTURE.md
+++ b/docs/EVENT-ARCHITECTURE.md
@@ -424,7 +424,11 @@ independently locked `listen --watch-follow` watchdog polls generation-bound sta
 and emits `event`/`listener-dead` when state is stale, faulted, missing, or invalid.
 The decomposed unsupervised path includes the exact re-arm command; under `supervise`
 the record keeps the reason but omits that action, and recovery is a supervisor restart.
-The watchdog never claims a delivery slot or
+Unreadable follow state is not death: do not arm another doorbell on
+`journal-unavailable` / `journal-io-failure` / busy / vanished-witness. Before
+acting on `listener-dead`, take positive control with `relay --new` (does a new
+event round-trip, is mail arriving). If inbound coverage is intact, it is
+contention. The watchdog never claims a delivery slot or
 reads the mail cursor. This makes persistent coverage a shared four-component
 `live/4` fact. It stays persistent after stream death, so the surviving backup pool and
 watchdog report `3/4`, not portable `1/4`.
@@ -482,9 +486,11 @@ also carries projection `age_s`; an hour-old projection becomes `stale` even whe
 `tasks.jsonl` has not changed.
 
 `--listener-slots`, `GOALFLIGHT_LISTENER_SLOTS`, and
-`GOALFLIGHT_LISTENER_LOW_WATER` remain portable-pool controls. Persistent backup
-depth is `GOALFLIGHT_PERSISTENT_BACKUP_SLOTS` (default 2; target depth, not a
-ceiling). `follow` rejects
+`GOALFLIGHT_LISTENER_LOW_WATER` remain portable-pool controls.
+`--listener-slots` is a live-depth ceiling: a new waiter must not raise
+concurrent doorbells above the target. Persistent backup
+depth is `GOALFLIGHT_PERSISTENT_BACKUP_SLOTS` (default 2; how many backup
+children `supervise` starts). `follow` rejects
 the CLI knob and warns on the portable environment knobs; persistent depth is
 the stream, the backup doorbell pool, and the watchdog.
 

--- a/protocols/controller-mail.md
+++ b/protocols/controller-mail.md
@@ -321,8 +321,9 @@ each poll; stale, faulted, missing, or invalid state makes it emit a structural
 `event`/`listener-dead` record on stdout and exit. In the decomposed unsupervised
 path that record carries the exact persistent re-arm command; under `supervise` it
 keeps the reason but omits the component action, and recovery is a supervisor restart.
-Unreadable follow state (journal-unavailable, journal-io-failure, busy, vanished-witness)
-is retryable degradation, not death: it must not set `backup_required` or a
+Unreadable follow state (journal-unavailable, journal-io-failure, busy,
+vanished-witness, monitor-state-io) is retryable degradation, not death:
+it must not set `backup_required` or a
 `rearm_command`. Before acting on `listener-dead`, take positive control with
 `relay --new` (does a new event round-trip, is mail arriving). If inbound coverage
 is intact, the alarm is journal contention — heartbeats the supervisor cannot

--- a/protocols/controller-mail.md
+++ b/protocols/controller-mail.md
@@ -320,7 +320,14 @@ bound durable liveness state. The separately tracked watchdog below reads that s
 each poll; stale, faulted, missing, or invalid state makes it emit a structural
 `event`/`listener-dead` record on stdout and exit. In the decomposed unsupervised
 path that record carries the exact persistent re-arm command; under `supervise` it
-keeps the reason but omits the component action, and recovery is a supervisor restart. Any event is also liveness
+keeps the reason but omits the component action, and recovery is a supervisor restart.
+Unreadable follow state (journal-unavailable, journal-io-failure, busy, vanished-witness)
+is retryable degradation, not death: it must not set `backup_required` or a
+`rearm_command`. Before acting on `listener-dead`, take positive control with
+`relay --new` (does a new event round-trip, is mail arriving). If inbound coverage
+is intact, the alarm is journal contention — heartbeats the supervisor cannot
+read, not a stopped listener. Do not arm another doorbell; extras stick and
+deepen the contention. Any event is also liveness
 evidence and defers the next idle heartbeat, so a batched heartbeat never claims "no
 mail" beside an event. An unchanged frontier emits only every 15 minutes; a change
 emits on the next idle beat.
@@ -361,9 +368,11 @@ backup command. Persistent coverage is four required slots: one live, healthy
 monitor stream, two backup doorbells, and one watchdog. Status, entry hints, and fleet
 output use that shared `live/4` predicate; after stream loss the surviving backup pool
 and watchdog report persistent coverage `3/4`, never a portable `1/4` pool. Override
-with `GOALFLIGHT_PERSISTENT_BACKUP_SLOTS` (default 2; target depth, not a
-ceiling). A shortfall is degraded, not binary-dead: a controller with some
-doorbells still covered should top the pool up.
+with `GOALFLIGHT_PERSISTENT_BACKUP_SLOTS` (default 2; how many backup
+children `supervise` starts). `--listener-slots` is a live-depth ceiling.
+A shortfall is degraded, not binary-dead: a controller with some
+doorbells still covered should top the pool up, but must not raise live
+depth above the cap.
 
 This is a bounded witness chain, not complete failure coverage. A lone watchdog death
 is loud, and correlated stream-plus-watchdog death is still loud while the backup

--- a/scripts/goalflight_messages.py
+++ b/scripts/goalflight_messages.py
@@ -6321,6 +6321,58 @@ def _is_supervised_child() -> bool:
     return os.environ.get("GOALFLIGHT_SUPERVISED") == "1"
 
 
+_UNREADABLE_FOLLOW_REASONS = frozenset(
+    {
+        "journal-unavailable",
+        "journal-io-failure",
+        "journal-unreadable",
+        "monitor-state-io",
+        "vanished-witness",
+        "busy",
+    }
+)
+
+
+def _follow_reason_is_unreadable(reason: object) -> bool:
+    token = str(reason or "").strip().lower()
+    return token in _UNREADABLE_FOLLOW_REASONS
+
+
+def _follow_status_reason(status: dict[str, object]) -> str:
+    fault = status.get("fault")
+    if isinstance(fault, dict):
+        return str(fault.get("reason") or "fault")
+    return str(status.get("reason") or status.get("state") or "stale")
+
+
+def _follow_status_is_readable_dead(status: dict[str, object]) -> bool:
+    """True only when a readable follow/lease state says the listener is gone.
+
+    Unreadable, busy, or vanished-witness observations are contention, not
+    death. A genuine death needs a readable stale/fault state whose age has
+    reached ``dead_after_s``.
+    """
+    if status.get("state") == "unreadable":
+        return False
+    reason = _follow_status_reason(status)
+    if _follow_reason_is_unreadable(reason):
+        return False
+    state = status.get("state")
+    if state == "fault":
+        # Follow itself recorded a readable death; age is not required.
+        return True
+    if state != "stale":
+        return False
+    try:
+        age = float(status.get("age_s") or 0.0)
+        dead_after = float(status.get("dead_after_s") or 0.0)
+    except (TypeError, ValueError):
+        return False
+    if not math.isfinite(age) or not math.isfinite(dead_after) or dead_after <= 0:
+        return False
+    return age >= dead_after
+
+
 def _wake_recovery_action(
     project_root: Path,
     *,
@@ -6328,8 +6380,23 @@ def _wake_recovery_action(
     lease_nonce: str,
     component_command: str,
     parent_gone: bool = False,
+    reason: str | None = None,
 ) -> dict[str, str | None]:
-    """Apply the shared supervisor detector before exposing recovery action."""
+    """Apply the shared supervisor detector before exposing recovery action.
+
+    Retryable journal unreadability must never become ``arm-component``.
+    """
+    if _follow_reason_is_unreadable(reason):
+        return {
+            "kind": "hold",
+            "state": None,
+            "command": None,
+            "instruction": (
+                "journal unreadability is retryable, not a dead listener; "
+                "confirm inbound coverage with relay --new before arming "
+                "another doorbell"
+            ),
+        }
     supervisor = goalflight_wake.supervisor_generation_state(
         project_root,
         controller_label=controller_label,
@@ -6556,26 +6623,32 @@ def _follow_dead_record(
     lease_nonce: str,
     rearm_command: str,
 ) -> dict[str, object]:
-    fault = status.get("fault")
-    reason = (
-        str(fault.get("reason") or "fault")
-        if isinstance(fault, dict)
-        else str(status.get("state") or "stale")
-    )
+    reason = _follow_status_reason(status)
+    readable_dead = _follow_status_is_readable_dead(status)
+    try:
+        age_s = round(float(status.get("age_s") or 0.0), 1)
+    except (TypeError, ValueError):
+        age_s = 0.0
+    try:
+        dead_after_s = float(status.get("dead_after_s") or 0.0)
+    except (TypeError, ValueError):
+        dead_after_s = 0.0
     payload: dict[str, object] = {
         "type": "listener-dead",
         "reason": _truncate_utf8(reason, 72),
-        "age_s": round(float(status.get("age_s") or 0.0), 1),
-        "dead_after_s": float(status.get("dead_after_s") or 0.0),
-        "backup_required": True,
+        "age_s": age_s,
+        "dead_after_s": dead_after_s,
     }
+    if readable_dead:
+        payload["backup_required"] = True
     action = _wake_recovery_action(
         project_root,
         controller_label=controller_label,
         lease_nonce=lease_nonce,
         component_command=rearm_command,
+        reason=reason,
     )
-    if action["kind"] == "arm-component":
+    if readable_dead and action["kind"] == "arm-component":
         payload["rearm_command"] = rearm_command
     elif action["kind"] == "verify-supervisor":
         payload["wake_recovery_hint"] = str(action["instruction"])
@@ -7289,6 +7362,8 @@ def _cmd_watch_follow(
         project_root,
         controller_label=label,
     )
+    monitor_unreadable = False
+    monitor_unreadable_since = 0.0
     state_grace = (
         0.1
         if os.environ.get("GOALFLIGHT_TEST_MODE") == "1"
@@ -7423,6 +7498,38 @@ def _cmd_watch_follow(
                 project_root,
                 controller_label=label,
             )
+            if follow_status and follow_status.get("state") == "unreadable":
+                if not monitor_unreadable:
+                    monitor_unreadable = True
+                    monitor_unreadable_since = time.monotonic()
+                    reason = _follow_status_reason(follow_status)
+                    detail = ""
+                    fault = follow_status.get("fault")
+                    if isinstance(fault, dict):
+                        detail = str(fault.get("detail") or "")
+                    alive = _write_follow_record(
+                        _follow_degraded_record(
+                            reason,
+                            detail or "durable follow state could not be read",
+                            journal_tolerance.tolerance_s,
+                        ),
+                        stream=sys.stdout,
+                    )
+                    if not alive:
+                        _silence_broken_stdout(sys.stdout)
+                        return 2
+                time.sleep(poll)
+                continue
+            if monitor_unreadable:
+                degraded_s = time.monotonic() - monitor_unreadable_since
+                monitor_unreadable = False
+                alive = _write_follow_record(
+                    _follow_recovered_record("monitor-state-io", degraded_s),
+                    stream=sys.stdout,
+                )
+                if not alive:
+                    _silence_broken_stdout(sys.stdout)
+                    return 2
             preexisting_dead_state = (
                 elapsed < state_grace
                 and current_state_stamp == startup_state_stamp
@@ -7444,7 +7551,7 @@ def _cmd_watch_follow(
             if (
                 not preexisting_dead_state
                 and follow_status is not None
-                and follow_status.get("state") in {"fault", "stale"}
+                and _follow_status_is_readable_dead(follow_status)
             ):
                 payload = _follow_dead_record(
                     follow_status,
@@ -7496,18 +7603,18 @@ def cmd_listen(args) -> int:
 
     Self-resolves the journal ACTIVE lease when ``--lease-nonce`` is omitted.
 
-    Arming never refuses for pool depth: a waiter takes the first free
-    listener slot with no upper bound. ``--listener-slots`` /
-    ``$GOALFLIGHT_LISTENER_SLOTS`` is the target depth the supervisor
-    chooses to run (live/target), not a ceiling.
+    ``--listener-slots`` / ``$GOALFLIGHT_LISTENER_SLOTS`` is a live-depth
+    ceiling. A new waiter must not raise concurrent listeners above that
+    target. Replacing a released (dead) slot is fine. An extra arm that
+    would exceed the cap fails closed with exit 3; the stderr names the
+    cap and says this is contention protection, not a ring.
 
-    Exit 3 no longer means a full-pool refusal - that overload is gone with
-    the ceiling. It is NOT reducible to "mail pending", though: this command
-    also returns 3 when the watchdog slot is already held, when the child is
-    orphaned (parent changed, or controlling stdout closed), and when the
-    lease generation has gone stale. A caller that branches on 3 must read the
-    accompanying stderr reason rather than assuming contention; re-arming
-    blindly on 3 will loop on the orphaned and stale-lease cases.
+    Exit 3 is also returned when the watchdog slot is already held, when
+    the child is orphaned (parent changed, or controlling stdout closed),
+    and when the lease generation has gone stale. A caller that branches
+    on 3 must read the accompanying stderr reason rather than assuming
+    mail; re-arming blindly on 3 will loop on the orphaned and stale-lease
+    cases.
 
     Exit 5 is settled did-not-arm: a dead or mismatched lease nonce, or no
     live controller lease. It is not a ring (0), not a retryable journal
@@ -7667,6 +7774,10 @@ def cmd_listen(args) -> int:
             generation_key=nonce,
             slots=listener_slots,
         )
+    except BlockingIOError as exc:
+        detail = exc.strerror or str(exc)
+        print(f"listen: refused: {detail}", file=sys.stderr)
+        return 3
     except (OSError, RuntimeError, ValueError) as exc:
         print(f"listen: wake ledger registration failed: {exc}", file=sys.stderr)
         return 2
@@ -9003,9 +9114,11 @@ def _run_cli(argv: list[str] | None = None) -> int:
             type=int,
             default=None,
             help=(
-                "target doorbell depth (how many to run; live/target), not a "
-                "ceiling; defaults to GOALFLIGHT_LISTENER_SLOTS or "
-                f"{goalflight_wake.DEFAULT_LISTENER_SLOTS}"
+                "live-depth ceiling: a new waiter must not raise concurrent "
+                "doorbells above this target; replacing a dead slot is fine; "
+                "extras that would exceed the cap fail closed as contention "
+                "protection, not a ring; defaults to GOALFLIGHT_LISTENER_SLOTS "
+                f"or {goalflight_wake.DEFAULT_LISTENER_SLOTS}"
             ),
         )
         command_parser.add_argument(
@@ -9042,7 +9155,9 @@ def _run_cli(argv: list[str] | None = None) -> int:
             action="store_true",
             help=(
                 "watchdog-only mode: wake with listener-dead when durable "
-                "follow records stop; does not deliver mail or consume a listener slot"
+                "follow records stop; unreadable records are retryable "
+                "degradation, not a stopped listener; does not deliver mail "
+                "or consume a listener slot"
             ),
         )
 
@@ -9055,10 +9170,10 @@ def _run_cli(argv: list[str] | None = None) -> int:
         description=(
             "one-shot journal cursor listener; self-resolves the ACTIVE lease "
             "unless --lease-nonce pins one. Exit 0 is a ring, 2 is a retryable "
-            "fault, 3 is contention/stale after arming, 5 is settled did-not-arm "
-            "(dead or mismatched lease nonce). Exit 3 is never a full-pool "
-            "refusal. --listener-slots is how many doorbells to run "
-            "(live/target), not a ceiling."
+            "fault, 3 is contention/stale after arming or a listener-slots cap "
+            "refusal, 5 is settled did-not-arm (dead or mismatched lease nonce). "
+            "--listener-slots is a live-depth ceiling: extras that would exceed "
+            "the cap fail closed as contention protection, not a ring."
         ),
     )
     add_listen_arguments(listen)
@@ -9067,9 +9182,8 @@ def _run_cli(argv: list[str] | None = None) -> int:
         help="alias for listen (kept for live fleet and SessionStart invocations)",
         description=(
             "alias for listen. Exit 0 is a ring, 2 is a retryable "
-            "fault, 3 is contention/stale after arming, 5 is settled did-not-arm "
-            "(dead or mismatched lease nonce). Exit 3 is never a full-pool "
-            "refusal."
+            "fault, 3 is contention/stale after arming or a listener-slots cap "
+            "refusal, 5 is settled did-not-arm (dead or mismatched lease nonce)."
         ),
     )
     add_listen_arguments(listen_auto)

--- a/scripts/goalflight_wake.py
+++ b/scripts/goalflight_wake.py
@@ -2625,10 +2625,12 @@ def coverage_status(
             else "unavailable"
         )
         monitor_lock_live = bool(monitor_waiters)
+        # Unreadable is contention, not health and not absence. Fail closed
+        # as unavailable so coverage cannot claim a torn follow file is live.
         monitor_healthy = (
             monitor_lock_live
             and durable_monitor is not None
-            and durable_state not in {"fault", "stale"}
+            and durable_state not in {"fault", "stale", "unreadable"}
         )
         backup_target = persistent_backup_slot_count()
         backup_observed = len(portable_waiters)
@@ -2643,7 +2645,7 @@ def coverage_status(
         watchdog_live = bool(watchdog_waiters)
         monitor_state = (
             "unavailable"
-            if durable_monitor is None
+            if durable_monitor is None or durable_state == "unreadable"
             else durable_state
             if durable_state in {"fault", "stale"}
             else "live"

--- a/scripts/goalflight_wake.py
+++ b/scripts/goalflight_wake.py
@@ -71,11 +71,11 @@ _MONITOR_STATE_FILE_VERSION = "monitor-state-v1"
 MONITOR_STATE_SCHEMA = "goalflight.monitor-state.v1"
 _OBSERVED_WAITERS_UNSET = object()
 _LEASE_EVENT_SCHEMA = "goalflight.lease-generation-event.v1"
-# Depth is resilience, not efficiency: one event wakes exactly one slot, so
-# extra armed waiters are the margin for a controller that forgets to re-arm.
-# GOALFLIGHT_LISTENER_SLOTS is how many doorbells the supervisor chooses to
-# run (live/target), not a ceiling on how many may arm.
-# This knob is portable-pool only. Persistent backup depth is
+# Depth is resilience, not efficiency: one event wakes exactly one slot.
+# GOALFLIGHT_LISTENER_SLOTS is the live-depth ceiling: a new waiter must
+# not raise concurrent listeners above this target. Replacing a released
+# (dead) slot is fine. Exceeding the cap is contention protection, not a
+# ring. This knob is portable-pool only. Persistent backup depth is
 # DEFAULT_PERSISTENT_BACKUP_SLOTS / GOALFLIGHT_PERSISTENT_BACKUP_SLOTS.
 DEFAULT_LISTENER_SLOTS = 4
 # Persistent wake has three roles: 1 stream, N backup doorbells, 1 watchdog.
@@ -509,24 +509,50 @@ def activate_monitor_state(
     return payload
 
 
+def _probe_monitor_state(
+    project_root: Path | str,
+    *,
+    controller_label: str,
+    lease_nonce: str,
+) -> tuple[str, dict[str, object] | None]:
+    """Return ``(ok|missing|unreadable, payload)``.
+
+    ``missing`` is a readable observation that this generation has no state
+    file (or the file is for another generation). ``unreadable`` is present-
+    path IO or a torn/invalid parse — contention, not absence.
+    """
+    path = _monitor_state_path(project_root, controller_label=controller_label)
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return "missing", None
+    except OSError:
+        return "unreadable", None
+    try:
+        payload = json.loads(text)
+    except (UnicodeError, json.JSONDecodeError):
+        return "unreadable", None
+    if (
+        not isinstance(payload, dict)
+        or payload.get("schema") != MONITOR_STATE_SCHEMA
+        or payload.get("generation") != _monitor_generation_digest(lease_nonce)
+    ):
+        return "missing", None
+    return "ok", payload
+
+
 def _load_monitor_state(
     project_root: Path | str,
     *,
     controller_label: str,
     lease_nonce: str,
 ) -> dict[str, object] | None:
-    path = _monitor_state_path(project_root, controller_label=controller_label)
-    try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeError, json.JSONDecodeError):
-        return None
-    if (
-        not isinstance(payload, dict)
-        or payload.get("schema") != MONITOR_STATE_SCHEMA
-        or payload.get("generation") != _monitor_generation_digest(lease_nonce)
-    ):
-        return None
-    return payload
+    kind, payload = _probe_monitor_state(
+        project_root,
+        controller_label=controller_label,
+        lease_nonce=lease_nonce,
+    )
+    return payload if kind == "ok" else None
 
 
 def record_monitor_emit(
@@ -589,12 +615,26 @@ def monitor_status(
     lease_nonce: str,
     now_epoch: float | None = None,
 ) -> dict[str, object] | None:
-    payload = _load_monitor_state(
+    kind, payload = _probe_monitor_state(
         project_root,
         controller_label=controller_label,
         lease_nonce=lease_nonce,
     )
-    if payload is None:
+    if kind == "unreadable":
+        return {
+            "capable": True,
+            "state": "unreadable",
+            "reason": "monitor-state-io",
+            "age_s": None,
+            "heartbeat_s": None,
+            "dead_after_s": None,
+            "last_kind": None,
+            "fault": {
+                "reason": "monitor-state-io",
+                "detail": "durable follow state exists but could not be read",
+            },
+        }
+    if kind != "ok" or payload is None:
         return None
     now = time.time() if now_epoch is None else float(now_epoch)
     try:
@@ -606,7 +646,19 @@ def monitor_status(
             float(payload["dead_after_s"]),
         )
     except (KeyError, TypeError, ValueError):
-        return None
+        return {
+            "capable": True,
+            "state": "unreadable",
+            "reason": "monitor-state-io",
+            "age_s": None,
+            "heartbeat_s": None,
+            "dead_after_s": None,
+            "last_kind": None,
+            "fault": {
+                "reason": "monitor-state-io",
+                "detail": "durable follow state is present but not parseable",
+            },
+        }
     age = max(0.0, now - (last_record if last_record is not None else activated))
     fault = payload.get("fault")
     state = (
@@ -1487,10 +1539,10 @@ class WaiterRegistration:
                 else:
                     if kind != "listener":
                         raise ValueError("generation slots are only valid for listeners")
-                    # Target depth is not a ceiling: take the first free
-                    # listener-slot-N lock with no upper bound.
+                    # Target depth is a ceiling. Replacing a released slot is
+                    # fine; taking slot N when 0..N-1 are all held is not.
                     slot = 0
-                    while self._generation_fd < 0:
+                    while self._generation_fd < 0 and slot < generation_slots:
                         candidate = _listener_slot_lock_path(
                             project_root,
                             label=normalized_label,
@@ -1508,6 +1560,14 @@ class WaiterRegistration:
                         self._generation_path = candidate
                         self._generation_fd = generation_fd
                         self.slot_index = slot
+                    if self._generation_fd < 0:
+                        raise BlockingIOError(
+                            errno.EAGAIN,
+                            (
+                                f"listener-slots cap is {generation_slots}; "
+                                "this is contention protection, not a ring"
+                            ),
+                        )
             pending_name = f".{record_name}.{uuid.uuid4().hex}.pending"
             self._fd = os.open(
                 pending_name,
@@ -1901,10 +1961,10 @@ def listener_low_water(target: int | None = None) -> int:
 
 
 def listener_slot_count(value: object = None) -> int:
-    """Resolve the listener-pool target depth (how many doorbells to run).
+    """Resolve the listener-pool live-depth ceiling.
 
-    This is not a ceiling on concurrent waiters. Registration takes the
-    first free slot with no upper bound.
+    A new waiter must not raise concurrent listeners above this target.
+    Replacing a released (dead) slot is fine.
     """
     raw = value
     if raw is None:
@@ -1921,8 +1981,8 @@ def listener_slot_count(value: object = None) -> int:
 def persistent_backup_slot_count(value: object = None) -> int:
     """Resolve the persistent backup-doorbell target depth.
 
-    This is not a ceiling on concurrent waiters. Registration takes the
-    first free slot with no upper bound.
+    Supervise starts this many backup children. Each child's
+    ``--listener-slots`` value is the live-depth ceiling for listen.
     """
     raw = value
     if raw is None:
@@ -1953,8 +2013,9 @@ def register_listener_waiter(
 ) -> WaiterRegistration:
     """Take the first free listener-slot-N lock for one lease generation.
 
-    ``slots`` selects the target depth (how many to run). It is not a
-    ceiling; this always takes the first free slot.
+    ``slots`` is the live-depth ceiling. Replacing a released slot is
+    fine; a waiter that would raise live depth above ``slots`` fails
+    closed with ``BlockingIOError`` (contention protection, not a ring).
     """
     resolved_slots = listener_slot_count(slots)
     return register_waiter(

--- a/tests/python/test_follow_listener.py
+++ b/tests/python/test_follow_listener.py
@@ -1135,7 +1135,7 @@ def test_watchdog_generation_lock_is_independent_of_listener_slot(
                 project,
                 controller_label=lease.label,
                 generation_key=lease.nonce,
-                slots=1,
+                slots=2,
             )
             try:
                 assert extra.slot_index == 1
@@ -1257,7 +1257,7 @@ def test_follow_backup_and_watchdog_coexist_and_sigkill_wakes(
             project,
             controller_label=lease.label,
             generation_key=lease.nonce,
-            slots=1,
+            slots=2,
         )
         try:
             assert extra.slot_index == 1
@@ -1572,6 +1572,7 @@ def test_watchdog_reads_durable_age_and_wakes_with_exact_rearm(
     assert lines[-1]["kind"] == "event"
     assert lines[-1]["payload"]["type"] == "listener-dead"
     assert lines[-1]["payload"]["reason"] == "stale"
+    assert lines[-1]["payload"]["backup_required"] is True
     assert lines[-1]["payload"]["rearm_command"] == wake.follow_start_command(
         project,
         controller_label=lease.label,
@@ -1719,6 +1720,83 @@ def test_watchdog_wakes_when_durable_follow_state_never_appears(
     assert lines[-1]["kind"] == "event"
     assert lines[-1]["payload"]["type"] == "listener-dead"
     assert lines[-1]["payload"]["reason"] == "state-unavailable"
+    assert lines[-1]["payload"]["backup_required"] is True
+
+
+def test_monitor_status_distinguishes_unreadable_from_missing(
+    isolated: tuple[Path, dict[str, str], journal.LeaseIdentity],
+) -> None:
+    project, _env, lease = isolated
+    assert (
+        wake.monitor_status(
+            project,
+            controller_label=lease.label,
+            lease_nonce=lease.nonce,
+        )
+        is None
+    )
+    wake.activate_monitor_state(
+        project,
+        controller_label=lease.label,
+        lease_nonce=lease.nonce,
+        heartbeat_s=60,
+        dead_after_s=180,
+    )
+    path = wake._monitor_state_path(project, controller_label=lease.label)
+    path.write_text("{not-json", encoding="utf-8")
+    status = wake.monitor_status(
+        project,
+        controller_label=lease.label,
+        lease_nonce=lease.nonce,
+    )
+    assert status is not None
+    assert status["state"] == "unreadable"
+    assert status["reason"] == "monitor-state-io"
+    assert status.get("age_s") is None
+
+
+def test_watchdog_unreadable_follow_state_does_not_set_backup_required(
+    isolated: tuple[Path, dict[str, str], journal.LeaseIdentity],
+) -> None:
+    project, env, lease = isolated
+    wake.activate_monitor_state(
+        project,
+        controller_label=lease.label,
+        lease_nonce=lease.nonce,
+        heartbeat_s=60,
+        dead_after_s=180,
+    )
+    path = wake._monitor_state_path(project, controller_label=lease.label)
+    path.write_text("{not-json", encoding="utf-8")
+    completed = subprocess.run(
+        _watch_command(project, lease, timeout_s=1),
+        cwd=project,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=8,
+    )
+    assert completed.returncode == 1, completed.stderr
+    lines = [json.loads(line) for line in completed.stdout.splitlines() if line]
+    dead = [
+        row
+        for row in lines
+        if row.get("kind") == "event"
+        and isinstance(row.get("payload"), dict)
+        and row["payload"].get("type") == "listener-dead"
+    ]
+    assert not dead, dead
+    degraded = [
+        row
+        for row in lines
+        if row.get("kind") == "event"
+        and isinstance(row.get("payload"), dict)
+        and row["payload"].get("type") == "listener-degraded"
+    ]
+    assert degraded
+    assert degraded[0]["payload"]["reason"] == "monitor-state-io"
+    assert "backup_required" not in degraded[0]["payload"]
+    assert "rearm_command" not in degraded[0]["payload"]
 
 
 def test_default_death_threshold_requires_three_missed_heartbeats() -> None:

--- a/tests/python/test_follow_listener.py
+++ b/tests/python/test_follow_listener.py
@@ -1176,8 +1176,10 @@ def test_fleet_console_uses_shared_persistent_coverage_predicate(
         )
     context = contexts[lease.nonce]
     assert context["wake_mode"] == "persistent"
-    assert context["listener_live"] == 1
-    assert context["listener_target"] == wake.persistent_wake_target()
+    coverage = context["wake_coverage"]
+    assert isinstance(coverage, dict)
+    assert coverage["live_waiters"] == 1
+    assert coverage["target_waiters"] == wake.persistent_wake_target()
 
 
 def test_follow_backup_and_watchdog_coexist_and_sigkill_wakes(

--- a/tests/python/test_goalflight_p3.py
+++ b/tests/python/test_goalflight_p3.py
@@ -2511,11 +2511,10 @@ def test_second_real_doorbell_takes_next_slot_and_first_wakes_body_free(
 ) -> None:
     env = _set_state_env(monkeypatch, tmp_path)
     env["GOALFLIGHT_TEST_LISTENER_START_TOKEN"] = "constructed-listener-token"
-    # Target depth 1 is how many to run, not a ceiling: a second doorbell
-    # must take the next free slot. Release it before the ring so the first
-    # uniquely receives the mail.
-    env["GOALFLIGHT_LISTENER_SLOTS"] = "1"
-    monkeypatch.setenv("GOALFLIGHT_LISTENER_SLOTS", "1")
+    # Target depth 2 lets a second waiter occupy the spare slot. Release it
+    # before the ring so the first uniquely receives the mail.
+    env["GOALFLIGHT_LISTENER_SLOTS"] = "2"
+    monkeypatch.setenv("GOALFLIGHT_LISTENER_SLOTS", "2")
     project = _project(tmp_path)
     authority = journal.open_or_create_journal(project)
     lease = _claim(authority)
@@ -2554,7 +2553,7 @@ def test_second_real_doorbell_takes_next_slot_and_first_wakes_body_free(
             project,
             controller_label="controller",
             generation_key=lease.nonce,
-            slots=1,
+            slots=2,
         )
         try:
             assert extra.slot_index == 1

--- a/tests/python/test_goalflight_p3.py
+++ b/tests/python/test_goalflight_p3.py
@@ -2327,6 +2327,9 @@ def test_unowned_terminal_projection_wakes_armed_doorbell_three_runs(
     project = _project(tmp_path)
     authority = journal.open_or_create_journal(project)
     lease = _claim(authority, "controller")
+    holder = wake.register_lease_holder(
+        project, controller_label="controller", lease_nonce=lease.nonce
+    )
     command = [
         sys.executable,
         str(SCRIPTS / "goalflight_messages.py"),
@@ -2427,6 +2430,7 @@ def test_unowned_terminal_projection_wakes_armed_doorbell_three_runs(
                 listener.wait(timeout=2)
 
     assert len(measurements) == 3
+    holder.close()
 
 
 def test_cursor_cas_has_one_winner_under_32_way_contention(
@@ -2520,6 +2524,9 @@ def test_second_real_doorbell_takes_next_slot_and_first_wakes_body_free(
     lease = _claim(authority)
     before = authority.active_lease("controller")
     assert before is not None
+    holder = wake.register_lease_holder(
+        project, controller_label="controller", lease_nonce=lease.nonce
+    )
     command = [
         sys.executable,
         str(SCRIPTS / "goalflight_messages.py"),
@@ -2615,6 +2622,7 @@ def test_second_real_doorbell_takes_next_slot_and_first_wakes_body_free(
     assert after is not None
     assert after.renewed_at == before.renewed_at
     assert after.renew_deadline_at == before.renew_deadline_at
+    holder.close()
 
 
 def test_wait_path_terminal_commit_wakes_under_seeded_history_three_runs(
@@ -2805,6 +2813,9 @@ def test_listener_path_terminal_commit_wakes_under_seeded_history_three_runs(
     project = _project(tmp_path)
     authority = journal.open_or_create_journal(project)
     lease = _claim(authority)
+    holder = wake.register_lease_holder(
+        project, controller_label="controller", lease_nonce=lease.nonce
+    )
     dispatch_ids = [f"listener-latency-{index}" for index in range(3)]
 
     seeded_ids = [f"seeded-history-{index:04d}" for index in range(1397)] + dispatch_ids
@@ -2911,6 +2922,7 @@ def test_listener_path_terminal_commit_wakes_under_seeded_history_three_runs(
 
     assert len(measurements) == 3
     assert all(value < 5.0 for value in measurements)
+    holder.close()
 
 
 def test_lease_death_attention_materializes_on_listener_and_holder_lock_sides(
@@ -3211,6 +3223,9 @@ def test_hidden_consumers_use_journal_and_relay_is_peek_only(
     )
     assert lease_result.committed and lease_result.value is not None
     lease = lease_result.value
+    holder = wake.register_lease_holder(
+        project, controller_label="hidden", lease_nonce=lease.nonce
+    )
     messages.post_message(
         dispatch_id="hidden-stream",
         msg_type="controller-notice",
@@ -3337,6 +3352,7 @@ def test_hidden_consumers_use_journal_and_relay_is_peek_only(
             listener.kill()
             listener.communicate(timeout=3)
 
+    holder.close()
     retired = sessions.retire_controller(
         project,
         "hidden",

--- a/tests/python/test_goalflight_p3.py
+++ b/tests/python/test_goalflight_p3.py
@@ -2547,6 +2547,12 @@ def test_second_real_doorbell_takes_next_slot_and_first_wakes_body_free(
                 break
             time.sleep(0.01)
         else:
+            if first.poll() is not None:
+                out, err = first.communicate()
+                pytest.fail(
+                    f"first listener exited {first.returncode} before arming: "
+                    f"stdout={out!r} stderr={err!r}"
+                )
             pytest.fail("first listener never armed coverage")
 
         extra = wake.register_listener_waiter(

--- a/tests/python/test_listener_floor.py
+++ b/tests/python/test_listener_floor.py
@@ -429,7 +429,7 @@ def test_detached_single_call_is_refused_not_a_floor(
                 pass
 
 
-def test_arming_past_target_is_not_refused(
+def test_arming_past_target_is_refused(
     isolated: tuple[Path, dict[str, str]],
 ) -> None:
     project, env = isolated
@@ -455,17 +455,12 @@ def test_arming_past_target_is_not_refused(
         assert plan["command"] == command
         assert "commands" not in plan
         assert "hint" not in plan
-        extra = wake.register_listener_waiter(
-            project,
-            controller_label="floor-ctl",
-            generation_key=lease.nonce,
-        )
-        try:
-            live = wake.live_waiters(project, controller_label="floor-ctl") or []
-            assert len(live) == wake.DEFAULT_LISTENER_SLOTS + 1
-            assert extra.slot_index == wake.DEFAULT_LISTENER_SLOTS
-        finally:
-            extra.close()
+        with pytest.raises(BlockingIOError, match="contention protection"):
+            wake.register_listener_waiter(
+                project,
+                controller_label="floor-ctl",
+                generation_key=lease.nonce,
+            )
         live = wake.live_waiters(project, controller_label="floor-ctl") or []
         assert len(live) == wake.DEFAULT_LISTENER_SLOTS
     finally:

--- a/tests/python/test_rearm_hint_supervisor.py
+++ b/tests/python/test_rearm_hint_supervisor.py
@@ -1733,6 +1733,8 @@ def test_unsupervised_dead_events_keep_direct_rearm_command(
         rearm_command="EXACT UNSUPERVISED COMMAND",
     )
     assert record["payload"]["rearm_command"] == "EXACT UNSUPERVISED COMMAND"
+    if builder is messages._follow_dead_record:
+        assert record["payload"]["backup_required"] is True
     if builder is messages._watchdog_dead_record:
         assert record["payload"]["live"] == 1
         assert record["payload"]["target"] == 8
@@ -1832,6 +1834,71 @@ def test_dead_events_with_unavailable_process_table_stay_numberless_and_safe(
     assert "missing_components" not in payload
     assert "MUST NOT LEAK" not in json.dumps(record)
     assert "could not tell whether `supervise`" in payload["wake_recovery_hint"]
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        {
+            "state": "unreadable",
+            "reason": "monitor-state-io",
+            "age_s": 2613.0,
+            "dead_after_s": 360.0,
+            "fault": {"reason": "journal-unavailable", "detail": "busy"},
+        },
+        {
+            "state": "fault",
+            "age_s": 2613.0,
+            "dead_after_s": 360.0,
+            "fault": {"reason": "journal-io-failure", "detail": "sqlite"},
+        },
+        {
+            "state": "stale",
+            "age_s": 2613.0,
+            "dead_after_s": 360.0,
+            "reason": "vanished-witness",
+        },
+    ],
+)
+def test_unreadable_follow_status_omits_backup_required_and_rearm(
+    isolated: tuple[Path, journal.LeaseIdentity],
+    monkeypatch: pytest.MonkeyPatch,
+    status: dict[str, object],
+) -> None:
+    project, lease = isolated
+    monkeypatch.delenv("GOALFLIGHT_SUPERVISED", raising=False)
+    monkeypatch.setattr(wake, "_process_listing", lambda: [])
+    record = messages._follow_dead_record(
+        status,
+        project_root=project,
+        controller_label=lease.label,
+        lease_nonce=lease.nonce,
+        rearm_command="MUST NOT LEAK",
+    )
+    payload = record["payload"]
+    assert payload["type"] == "listener-dead"
+    assert payload.get("backup_required") is not True
+    assert "rearm_command" not in payload
+    assert "MUST NOT LEAK" not in json.dumps(record)
+
+
+def test_wake_recovery_action_does_not_arm_on_journal_unreadable(
+    isolated: tuple[Path, journal.LeaseIdentity],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project, lease = isolated
+    monkeypatch.delenv("GOALFLIGHT_SUPERVISED", raising=False)
+    monkeypatch.setattr(wake, "_process_listing", lambda: [])
+    action = messages._wake_recovery_action(
+        project,
+        controller_label=lease.label,
+        lease_nonce=lease.nonce,
+        component_command="MUST NOT ARM",
+        reason="journal-unavailable",
+    )
+    assert action["kind"] != "arm-component"
+    assert action.get("command") is None
+    assert "relay --new" in str(action.get("instruction") or "")
 
 
 def test_dead_event_contracts_scope_actions_to_unsupervised_paths() -> None:

--- a/tests/python/test_supervised_wake.py
+++ b/tests/python/test_supervised_wake.py
@@ -2462,7 +2462,7 @@ def test_supervisor_listener_dead_passthrough_does_not_mint_extra_backups() -> N
         scripts={
             "stream": [
                 PlannedExit(
-                    lifetime_s=80.0,
+                    lifetime_s=1000.0,
                     returncode=0,
                     armed=True,
                     stdout_lines=[
@@ -2471,35 +2471,25 @@ def test_supervisor_listener_dead_passthrough_does_not_mint_extra_backups() -> N
                 )
             ],
             "backup": [
-                PlannedExit(lifetime_s=80.0, returncode=0, armed=True),
-                PlannedExit(lifetime_s=80.0, returncode=0, armed=True),
+                PlannedExit(lifetime_s=1000.0, returncode=0, armed=True),
+                PlannedExit(lifetime_s=1000.0, returncode=0, armed=True),
             ],
             "watchdog": [
                 PlannedExit(
-                    lifetime_s=5.0,
+                    lifetime_s=1000.0,
                     returncode=0,
                     armed=True,
                     stdout_lines=[
                         (
-                            0.0,
-                            json.dumps(
-                                {
-                                    "kind": "event",
-                                    "payload": {
-                                        "type": "listener-dead",
-                                        "backup_required": True,
-                                        "rearm_command": "MUST NOT MINT BACKUP",
-                                    },
-                                }
-                            ),
+                            0.01,
+                            '{"kind":"event","payload":{"type":"listener-dead","backup_required":true,"rearm_command":"MUST NOT MINT BACKUP"}}',
                         ),
                     ],
                 ),
-                PlannedExit(lifetime_s=80.0, returncode=0, armed=True),
             ],
         },
         stop_when_lines_contain=('"type":"listener-dead"',),
-        stop_after_waits=40,
+        stop_after_waits=20,
     )
     _run(
         host,
@@ -2507,9 +2497,11 @@ def test_supervisor_listener_dead_passthrough_does_not_mint_extra_backups() -> N
         heartbeat_s=50.0,
         coverage_s=50.0,
     )
-    backup_spawns = [kind for kind, _command in host.spawns if kind == "backup"]
-    assert backup_spawns == ["backup", "backup"]
-    assert all(kind in {"stream", "backup", "watchdog"} for kind, _command in host.spawns)
+    kinds = [kind for kind, _command in host.spawns]
+    assert kinds.count("backup") == 2, kinds
+    assert kinds.count("stream") == 1
+    assert kinds.count("watchdog") == 1
+    assert set(kinds) == {"stream", "backup", "watchdog"}
     joined = "".join(host.lines)
     assert '"type":"listener-dead"' in joined
     assert "MUST NOT MINT BACKUP" in joined

--- a/tests/python/test_supervised_wake.py
+++ b/tests/python/test_supervised_wake.py
@@ -2456,6 +2456,65 @@ def test_opt_in_live_counts_armed_components_not_pids() -> None:
     assert coverages[-1]["live"] == coverages[-1]["target"] == 3
 
 
+def test_supervisor_listener_dead_passthrough_does_not_mint_extra_backups() -> None:
+    """Supervise respawns empty slots only; backup_required is not a spawn cue."""
+    host = FakeHost(
+        scripts={
+            "stream": [
+                PlannedExit(
+                    lifetime_s=80.0,
+                    returncode=0,
+                    armed=True,
+                    stdout_lines=[
+                        (0.0, '{"kind":"heartbeat","payload":{"seq":1}}'),
+                    ],
+                )
+            ],
+            "backup": [
+                PlannedExit(lifetime_s=80.0, returncode=0, armed=True),
+                PlannedExit(lifetime_s=80.0, returncode=0, armed=True),
+            ],
+            "watchdog": [
+                PlannedExit(
+                    lifetime_s=5.0,
+                    returncode=0,
+                    armed=True,
+                    stdout_lines=[
+                        (
+                            0.0,
+                            json.dumps(
+                                {
+                                    "kind": "event",
+                                    "payload": {
+                                        "type": "listener-dead",
+                                        "backup_required": True,
+                                        "rearm_command": "MUST NOT MINT BACKUP",
+                                    },
+                                }
+                            ),
+                        ),
+                    ],
+                ),
+                PlannedExit(lifetime_s=80.0, returncode=0, armed=True),
+            ],
+        },
+        stop_when_lines_contain=('"type":"listener-dead"',),
+        stop_after_waits=40,
+    )
+    _run(
+        host,
+        _items("stream", "backup", "backup", "watchdog"),
+        heartbeat_s=50.0,
+        coverage_s=50.0,
+    )
+    backup_spawns = [kind for kind, _command in host.spawns if kind == "backup"]
+    assert backup_spawns == ["backup", "backup"]
+    assert all(kind in {"stream", "backup", "watchdog"} for kind, _command in host.spawns)
+    joined = "".join(host.lines)
+    assert '"type":"listener-dead"' in joined
+    assert "MUST NOT MINT BACKUP" in joined
+
+
 def test_journal_unreadable_is_retryable_not_dead_nonce() -> None:
     host = FakeHost(
         scripts={

--- a/tests/python/test_wake_layer.py
+++ b/tests/python/test_wake_layer.py
@@ -1253,7 +1253,7 @@ def test_cursor_advance_with_leftovers_pops_one_more_pool_member(
             process.communicate(timeout=3)
 
 
-def test_listener_arm_past_target_is_not_refused_then_empty_pool_hint(
+def test_listener_arm_at_cap_then_empty_pool_hint(
     isolated: tuple[Path, dict[str, str]],
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1289,16 +1289,14 @@ def test_listener_arm_past_target_is_not_refused_then_empty_pool_hint(
     try:
         waiters = _wait_for_listener_count(root, label="wake-test", count=3)
         assert len(waiters) == 3
-        extra = wake.register_listener_waiter(
-            root,
-            controller_label="wake-test",
-            generation_key=claimed.value.nonce,
-            slots=3,
-        )
-        assert extra.slot_index == 3
+        with pytest.raises(BlockingIOError, match="contention protection"):
+            wake.register_listener_waiter(
+                root,
+                controller_label="wake-test",
+                generation_key=claimed.value.nonce,
+                slots=3,
+            )
         assert all(process.poll() is None for process in processes)
-        extra.close()
-        extra = None
 
         for index in range(3):
             _post_notice(
@@ -1343,7 +1341,7 @@ def test_listener_arm_past_target_is_not_refused_then_empty_pool_hint(
             process.communicate(timeout=3)
 
 
-def test_listener_arm_has_no_slot_ceiling(
+def test_listener_arm_refuses_above_slot_ceiling(
     isolated: tuple[Path, dict[str, str]],
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1354,14 +1352,14 @@ def test_listener_arm_has_no_slot_ceiling(
     env.pop("GOALFLIGHT_LISTENER_SLOTS", None)
     authority = journal.open_or_create_journal(root)
     claimed = authority.claim_or_renew_lease(
-        "wake-test", principal={"principal_id": "uncapped-arm"}
+        "wake-test", principal={"principal_id": "capped-arm"}
     )
     assert claimed.committed and claimed.value is not None
     nonce = claimed.value.nonce
     lease_holder = _hold_claimed_lease(root, claimed.value)
     holders: list[wake.WaiterRegistration] = []
     try:
-        for expected_slot in range(40):
+        for expected_slot in range(4):
             holder = wake.register_listener_waiter(
                 root,
                 controller_label="wake-test",
@@ -1376,21 +1374,36 @@ def test_listener_arm_has_no_slot_ceiling(
             )
             or []
         )
-        assert len(live) == 40
+        assert len(live) == 4
         status_payload = wake.coverage_status(
             root, controller_label="wake-test", lease_nonce=nonce
         )
-        assert status_payload["live_waiters"] == 40
+        assert status_payload["live_waiters"] == 4
         assert status_payload["target_waiters"] == wake.DEFAULT_LISTENER_SLOTS
-        forty_first = wake.register_listener_waiter(
+        with pytest.raises(BlockingIOError, match="contention protection"):
+            wake.register_listener_waiter(
+                root,
+                controller_label="wake-test",
+                generation_key=nonce,
+                slots=4,
+            )
+        holders[0].close()
+        replacement = wake.register_listener_waiter(
             root,
             controller_label="wake-test",
             generation_key=nonce,
             slots=4,
         )
-        holders.append(forty_first)
-        assert forty_first.slot_index == 40
-        contender = subprocess.run(
+        holders[0] = replacement
+        assert replacement.slot_index == 0
+        with pytest.raises(BlockingIOError, match="contention protection"):
+            wake.register_listener_waiter(
+                root,
+                controller_label="wake-test",
+                generation_key=nonce,
+                slots=4,
+            )
+        refused = subprocess.run(
             _listener_command(
                 root,
                 tmp_path,
@@ -1407,9 +1420,9 @@ def test_listener_arm_has_no_slot_ceiling(
             timeout=5,
             check=False,
         )
-        assert contender.returncode == 1, (contender.stdout, contender.stderr)
-        assert "hold live doorbells" not in contender.stderr
-        assert "full" not in contender.stderr.lower()
+        assert refused.returncode == 3, (refused.stdout, refused.stderr)
+        assert "listener-slots cap is 4" in refused.stderr
+        assert "contention protection, not a ring" in refused.stderr
         help_text = subprocess.run(
             [
                 sys.executable,
@@ -1425,14 +1438,10 @@ def test_listener_arm_has_no_slot_ceiling(
             check=False,
         )
         assert help_text.returncode == 0, help_text.stderr
-        # This test is about the CEILING, so pin the claim that is actually
-        # load-bearing here: arming is never refused for pool depth. The help
-        # text used to say "exit 3 means mail pending only" and this asserted
-        # it, but that claim is false - cmd_listen also returns 3 for a held
-        # watchdog slot, for both orphaned cases, and for a stale lease. Pinning
-        # a false sentence made the docs harder to correct than to leave wrong.
-        assert "never a full-pool refusal" in help_text.stdout
-        assert "not a ceiling" in help_text.stdout
+        assert "never a full-pool refusal" not in help_text.stdout
+        assert "not a ceiling" not in help_text.stdout
+        assert "live-depth ceiling" in help_text.stdout
+        assert "contention protection" in help_text.stdout
     finally:
         lease_holder.close()
         for holder in holders:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

A live battery-* fleet listener count went 14 → 20 in an hour while controllers reacted to `listener-dead`. Ages on those alarms were non-monotonic (361, 363, … then 2613). A real dead listener’s age climbs monotonically; jumps mean heartbeats the supervisor cannot **read**, not heartbeats that stopped.

Loop:

1. Journal contention made follow/watchdog heartbeats unreadable.
2. `_follow_dead_record` always set `backup_required: true` and could attach a `rearm_command`.
3. Controllers (or anything reacting to that field) armed extra `listen` processes.
4. `--listener-slots` was documented as live/target **not a ceiling**, so extras stuck.
5. More processes → more contention → more false `listener-dead` → repeat.

Hunch (verified in code, still labeled a hunch for the incident): hardcoded `backup_required=True` plus listen-has-no-ceiling is the whole loop. `supervise` does **not** read `backup_required`; it only respawns its configured slots. Controllers refraining does not stop the false alarms because supervise respawns `--watch-follow` on its own after a false dead, but the 14→20 growth is extras sticking past the cap.

Positive control at the time: `relay --new --summary-only` round-tripped, doorbell events arriving, zero mail backlog.

## Changes

- **Unreadable ≠ dead.** Torn/unreadable monitor state returns `state=unreadable` (`monitor-state-io`). Watch-follow emits `listener-degraded` / `listener-recovered` and keeps polling. `_follow_dead_record` sets `backup_required` only for a readable stale/fault death. `_wake_recovery_action` will not return `arm-component` for journal-unavailable / journal-io-failure / busy / vanished-witness / monitor-state-io.
- **`--listener-slots` is a ceiling.** Registration tries slots `0..N-1` only. A waiter that would raise live depth above the target fails closed with `BlockingIOError` / listen exit 3 naming the cap and saying this is contention protection, not a ring. Replacing a released slot is fine.
- **Supervise does not mint extras.** Confirmed: it only respawns the configured slot list. Test locks that a `listener-dead` passthrough with `backup_required` does not add backup kinds.
- **Docs.** Before acting on `listener-dead`, positive control is `relay --new`. If inbound coverage is intact, it is contention — do not arm another doorbell.

## Tests

Hermetic only:

- Unreadable follow/watchdog state does not set `backup_required` / `rearm_command`.
- Genuine stale / missing-after-grace still emit `listener-dead` with `backup_required`.
- Listen refuses a waiter that would exceed `--listener-slots`; a released slot can be replaced.
- Supervise does not mint extra backup kinds on a `listener-dead` passthrough.

## Out of scope

Does not steal leases, does not change keepalive from 120s, does not re-arm or tear down any live fleet supervisor.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aac1c870-5fb2-4589-bfa5-08162878c249?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aac1c870-5fb2-4589-bfa5-08162878c249&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

